### PR TITLE
入力帳票の入力欄を可視化し、報告済みの取りこぼしをふさぐ

### DIFF
--- a/apps/web-free/src/workspace/excel-import.ts
+++ b/apps/web-free/src/workspace/excel-import.ts
@@ -67,12 +67,25 @@ function toNetworkNode(node: NodeRow, warnings: string[]): Record<string, unknow
  * 部分データでも例外を投げない — 揃っている項目だけをマッピングし、
  * 省略・既定値化した項目は必ず `warnings` に理由を積む。
  */
-export function mapWorkbookToRunInputs(data: WorkbookData): { runInputs: Partial<Record<RunKind, unknown>>; warnings: string[] } {
+export function mapWorkbookToRunInputs(data: WorkbookData): {
+  runInputs: Partial<Record<RunKind, unknown>>
+  eventSettings: Record<string, unknown>
+  warnings: string[]
+} {
   const warnings: string[] = []
   const runInputs: Partial<Record<RunKind, unknown>> = {}
+  // 操作条件はモデル側ではなくシナリオの eventSettings に入る
+  // （core-py の protocol.py は closeTime をここから読む）。
+  const eventSettings: Record<string, unknown> = {}
 
   const pipe = data.pipes[0]
   const calculationCase = data.cases[0]
+
+  if (calculationCase?.closeTime !== undefined) {
+    eventSettings.closeTime = calculationCase.closeTime
+  } else if (calculationCase && (calculationCase.operationType === 'valve_close' || calculationCase.operationType === 'valve_open')) {
+    warnings.push(`ケース ${calculationCase.id}: 等価閉そく時間（close_time）が未入力のため、閉鎖時間は既定値のままにしました。解析タブで確認・入力してください。`)
+  }
 
   if (pipe) {
     runInputs.wave_speed = { pipe }
@@ -101,5 +114,5 @@ export function mapWorkbookToRunInputs(data: WorkbookData): { runInputs: Partial
     warnings.push('管路・節点シートに管路と節点の両方が揃っていないため、steady_network_python / steady_network_epanet の入力は作成しませんでした。')
   }
 
-  return { runInputs, warnings }
+  return { runInputs, eventSettings, warnings }
 }

--- a/apps/web-free/src/workspace/tabs/ExcelIoCard.tsx
+++ b/apps/web-free/src/workspace/tabs/ExcelIoCard.tsx
@@ -2,6 +2,7 @@ import type { Case, JsonValue, RunKind } from '@open-waterhammer/contracts'
 import type { ParseError } from '@open-waterhammer/excel-io'
 import {
   DEMO_CASE_01_CASE,
+  DEMO_CASE_01_NODES,
   DEMO_CASE_01_PIPE,
   DEMO_CASE_02_CASE,
   DEMO_MEASUREMENT_POINTS,
@@ -44,7 +45,7 @@ export function ExcelIoCard({ caseRecord }: { caseRecord: Case }) {
       const buf = await generateTemplate({
         meta: { projectName: '（案件名を入力）', standardId: 'nochi_pipeline_2021', methodId: 'joukowsky_v1' },
         pipes: [DEMO_CASE_01_PIPE],
-        nodes: [],
+        nodes: DEMO_CASE_01_NODES,
         cases: [DEMO_CASE_01_CASE, DEMO_CASE_02_CASE],
         measurementPoints: DEMO_MEASUREMENT_POINTS,
       })
@@ -80,6 +81,7 @@ export function ExcelIoCard({ caseRecord }: { caseRecord: Case }) {
         caseRecord.id,
         mapped.runInputs as Partial<Record<RunKind, JsonValue>>,
         result.data as unknown as JsonValue,
+        mapped.eventSettings as JsonValue,
       )
       setStatus(kinds.length > 0
         ? `${file.name} を読み込み、${kinds.join(' / ')} の入力を更新しました。`

--- a/docs/excel-template-spec.md
+++ b/docs/excel-template-spec.md
@@ -56,7 +56,7 @@
 |------------|------|----|------|------|------|
 | `node_id` | 節点ID | string | — | ○ | |
 | `node_name` | 節点名 | string | — | — | |
-| `elevation` | 地盤高 | float | m | ○ | T.P.基準推奨 |
+| `elevation` | 地盤高（標高） | float | m | ○ | T.P.基準推奨。帳票の表示名も「地盤高（標高）」で統一 |
 | `hydraulic_grade` | 動水位（初期値） | float | m | — | 定常計算で更新 |
 | `node_type` | 節点種別 | enum | — | ○ | `reservoir`, `junction`, `tank`, `pump_node`, `valve_node` |
 
@@ -78,18 +78,26 @@
 
 ##### 管種コード（参照: 表-8.2.1）
 
+コードと Eₛ の正本は `packages/core/src/pipe-materials.ts`（`PIPE_MATERIALS`）。
+
 | コード | 管種名 | Eₛ (×10⁶ kN/m²) |
 |--------|--------|-----------------|
 | `steel` | 鋼管 | 200 |
 | `ductile_iron` | ダクタイル鋳鉄管 | 160 |
 | `rcp` | 遠心力鉄筋コンクリート管 | 20 |
-| `cpcp` | コア式PCCP管 | 39 |
-| `upvc` | 硬質塩ビ管 | 3 |
-| `pe2` | 一般用PE管（2種） | 1 |
-| `pe3_pe100` | 一般用PE管（3種 PE100） | 1.3 |
-| `wdpe1`〜`wdpe5` | 水道配水用PE管 1〜5種 | 21.6/19.6/16.7/15.2/14.7 |
-| `grp_fw` | FW成形強化プラスチック複合管 | 51 |
-| `gfpe` | GF強化ポリエチレン管 | 2.5 |
+| `cpcp` | コア式プレストレストコンクリート管 | 39 |
+| `upvc` | 硬質ポリ塩化ビニル管 | 3 |
+| `pe2` | 一般用ポリエチレン管（2種） | 1 |
+| `pe3_pe100` | 一般用ポリエチレン管（3種 PE100） | 1.3 |
+| `wdpe` | 水道配水用ポリエチレン管 | 1.3 |
+| `grp_fw1` | 強化プラスチック複合管 FW（1種） | 14.7 |
+| `grp_fw2` | 強化プラスチック複合管 FW（2種） | 15.2 |
+| `grp_fw3` | 強化プラスチック複合管 FW（3種） | 16.7 |
+| `grp_fw4` | 強化プラスチック複合管 FW（4種） | 19.6 |
+| `grp_fw5` | 強化プラスチック複合管 FW（5種） | 21.6 |
+| `gfpe` | ガラス繊維強化ポリエチレン管 | 2.5 |
+
+樹脂系管材（`isResin: true`）の長期ヤング係数は短期値 × 0.8。
 
 ---
 
@@ -140,8 +148,9 @@
 | `description` | 説明 | string | — | |
 | `operation_type` | 操作種別 | enum | ○ | `valve_close`, `valve_open`, `pump_stop`, `pump_start`, `combined` |
 | `target_facility_id` | 対象施設ID | string | ○ | |
-| `initial_flow` | 初期流速 V₀ | float | ○ | m/s |
+| `initial_velocity` | 初期流速 V₀ | float | ○ | m/s。旧ID `initial_flow`（流速なのに flow という誤称）も読み取りのみ受け付ける |
 | `initial_head` | 初期圧力水頭 H₀ | float | ○ | m |
+| `close_time` | 等価閉そく時間 tν | float | — | s。`valve_close` / `valve_open` では必須。急緩判定とアリエビ式に使う |
 | `output_sheet` | 出力シートID | string | ○ | |
 
 ---

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -106,6 +106,13 @@ export interface CalculationCase {
   initialVelocity: number;
   /** 初期圧力水頭 H₀ [m] */
   initialHead: number;
+  /**
+   * 等価閉そく時間 tν [s]
+   *
+   * バルブ操作ケースでアリエビ式・急緩判定に使う。
+   * ポンプ操作ケースでは不要なため任意。
+   */
+  closeTime?: number;
 }
 
 // ─── 測点（成果品様式 水理計算書） ──────────────────────────────────────────────

--- a/packages/excel-io/src/reader.ts
+++ b/packages/excel-io/src/reader.ts
@@ -32,7 +32,19 @@ function requireNum(v: unknown, label: string, errors: ParseError[], sheet: stri
   return n;
 }
 
-/** 複合ヘッダー "field_id\n(日本語名)" → "field_id" に正規化 */
+/**
+ * 各行に埋め込む「実際のシート行番号」のキー。
+ * エラーメッセージの行番号を、空行を含む実際の位置に合わせるために使う。
+ * 列ヘッダーと衝突しないよう記号付きの名前にしている。
+ */
+const ROW_NUMBER = "__sheetRow__";
+
+function rowNumberOf(row: Record<string, unknown>, fallback: number): number {
+  const n = row[ROW_NUMBER];
+  return typeof n === "number" ? n : fallback;
+}
+
+/** 複合ヘッダー "field_id\n(日本語名)\n(入力区分)" → "field_id" に正規化 */
 function normalizeKey(key: string): string {
   const idx = key.indexOf("\n");
   return idx >= 0 ? key.substring(0, idx) : key;
@@ -83,7 +95,10 @@ function sheetToRows(ws: ExcelJS.Worksheet | undefined): Record<string, unknown>
       obj[h] = v;
       if (v !== null && v !== "") hasValue = true;
     }
-    if (hasValue) result.push(obj);
+    if (hasValue) {
+      obj[ROW_NUMBER] = r;
+      result.push(obj);
+    }
   }
   return result;
 }
@@ -154,7 +169,7 @@ function parsePipes(rows: Record<string, unknown>[], errors: ParseError[]): Pipe
   const pipes: Pipe[] = [];
   for (let i = 0; i < rows.length; i++) {
     const row = rows[i]!;
-    const rowNum = i + 2; // ヘッダー行を1とした場合
+    const rowNum = rowNumberOf(row, i + 2);
 
     const id = str(row["pipe_id"] ?? row["管路ID"]);
     if (!id) continue; // 空行はスキップ
@@ -189,7 +204,7 @@ function parseNodes(rows: Record<string, unknown>[], errors: ParseError[]): Node
   const nodes: Node[] = [];
   for (let i = 0; i < rows.length; i++) {
     const row = rows[i]!;
-    const rowNum = i + 2;
+    const rowNum = rowNumberOf(row, i + 2);
 
     const id = str(row["node_id"] ?? row["節点ID"]);
     if (!id) continue;
@@ -220,6 +235,7 @@ function parseNodes(rows: Record<string, unknown>[], errors: ParseError[]): Node
 function sectionToRows(
   raw: unknown[][],
   keyIndicators: string[],
+  rowOffset = 0,
 ): Record<string, unknown>[] {
   const headerIdx = raw.findIndex((row) =>
     keyIndicators.some((k) => str(row[0]).toLowerCase().includes(k)),
@@ -231,12 +247,16 @@ function sectionToRows(
 
   for (let i = headerIdx + 1; i < raw.length; i++) {
     const row = raw[i]!;
-    // コメント行・空行・次のセクション見出しはスキップ
     const first = str(row[0]);
-    if (first.startsWith("#") || headers.every((_, ci) => row[ci] == null || str(row[ci]) === "")) break;
+    // 次のセクション見出し（"# ..."）でこのセクションは終わり
+    if (first.startsWith("#")) break;
+    // 空行は飛ばす。ここで打ち切ると、表の途中に空行を挟んだときに
+    // それ以降の入力行が黙って読み捨てられてしまう。
+    if (headers.every((_, ci) => row[ci] == null || str(row[ci]) === "")) continue;
 
     const obj: Record<string, unknown> = {};
     headers.forEach((h, ci) => { if (h) obj[h] = row[ci] ?? null; });
+    obj[ROW_NUMBER] = rowOffset + i + 1;
     result.push(obj);
   }
 
@@ -257,7 +277,7 @@ function parseNetwork(wb: ExcelJS.Workbook, errors: ParseError[]): { pipes: Pipe
   const pipeRows = sectionToRows(raw, ["テーブル", "table", "pipe_id"]);
   const nodeStartIdx = raw.findIndex((r) => str(r[0]).includes("節点"));
   const nodeRaw = nodeStartIdx >= 0 ? raw.slice(nodeStartIdx + 1) : raw;
-  const nodeRows = sectionToRows(nodeRaw, ["テーブル", "table", "node_id"]);
+  const nodeRows = sectionToRows(nodeRaw, ["テーブル", "table", "node_id"], nodeStartIdx >= 0 ? nodeStartIdx + 1 : 0);
 
   return {
     pipes: parsePipes(pipeRows, errors),
@@ -271,7 +291,7 @@ const VALID_OPERATION_TYPES = new Set<string>([
   "valve_close", "valve_open", "pump_stop", "pump_start", "combined",
 ]);
 
-function parseCases(wb: ExcelJS.Workbook, errors: ParseError[]): CalculationCase[] {
+function parseCases(wb: ExcelJS.Workbook, errors: ParseError[], warnings: string[]): CalculationCase[] {
   const ws = wb.getWorksheet("ケース設定") ?? wb.getWorksheet("cases");
   if (!ws) {
     errors.push({ sheet: "cases", message: "「ケース設定」シートが見つかりません" });
@@ -283,7 +303,7 @@ function parseCases(wb: ExcelJS.Workbook, errors: ParseError[]): CalculationCase
 
   for (let i = 0; i < rows.length; i++) {
     const row = rows[i]!;
-    const rowNum = i + 2;
+    const rowNum = rowNumberOf(row, i + 2);
 
     const id = str(row["case_id"] ?? row["ケースID"]);
     if (!id) continue;
@@ -298,11 +318,17 @@ function parseCases(wb: ExcelJS.Workbook, errors: ParseError[]): CalculationCase
       name: str(row["case_name"] ?? row["ケース名"]) || id,
       operationType: (VALID_OPERATION_TYPES.has(opRaw) ? opRaw : "valve_close") as OperationType,
       targetFacilityId: str(row["target_facility_id"] ?? row["対象施設ID"]),
-      initialVelocity: requireNum(row["initial_flow"] ?? row["初期流速 V₀"], "初期流速 V₀", errors, "cases", rowNum),
+      // initial_flow は旧フィールドID（流速なのに flow という誤称）。既存ブックのため読み取りだけ残す。
+      initialVelocity: requireNum(row["initial_velocity"] ?? row["initial_flow"] ?? row["初期流速 V₀"], "初期流速 V₀", errors, "cases", rowNum),
       initialHead: requireNum(row["initial_head"] ?? row["初期圧力水頭 H₀"], "初期圧力水頭 H₀", errors, "cases", rowNum),
     };
     const desc = str(row["description"] ?? row["説明"]);
     if (desc) cas.description = desc;
+    const closeTime = num(row["close_time"] ?? row["等価閉そく時間 tν"]);
+    if (closeTime !== undefined) cas.closeTime = closeTime;
+    if (cas.closeTime === undefined && (cas.operationType === "valve_close" || cas.operationType === "valve_open")) {
+      warnings.push(`ケース ${cas.id}: 等価閉そく時間（close_time）が未入力です。急閉そく・緩閉そくの判定ができません。`);
+    }
     cases.push(cas);
   }
 
@@ -323,7 +349,7 @@ function parseMeasurementPoints(wb: ExcelJS.Workbook, errors: ParseError[]): Mea
 
   for (let i = 0; i < rows.length; i++) {
     const row = rows[i]!;
-    const rowNum = i + 2;
+    const rowNum = rowNumberOf(row, i + 2);
 
     const id = str(row["point_id"] ?? row["測点ID"]);
     if (!id) continue;
@@ -381,7 +407,7 @@ export async function parseWorkbook(buffer: ArrayBuffer | Buffer): Promise<Parse
 
   const meta = parseMeta(wb, errors);
   const { pipes, nodes } = parseNetwork(wb, errors);
-  const cases = parseCases(wb, errors);
+  const cases = parseCases(wb, errors, warnings);
   const measurementPoints = parseMeasurementPoints(wb, errors);
 
   if (pipes.length === 0) {

--- a/packages/excel-io/src/template.ts
+++ b/packages/excel-io/src/template.ts
@@ -3,6 +3,7 @@
  * デモケースを初期値として入力済みテンプレートを出力する
  *
  * exceljs ベース実装（xlsx/SheetJS から移行: 2026-05-08）
+ * 入力区分の色分け・凡例・用語対応表・入力規則を追加（2026-08-25）
  */
 
 import ExcelJS from "exceljs";
@@ -18,93 +19,367 @@ interface TemplateOptions {
   measurementPoints?: MeasurementPoint[];
 }
 
-// ─── シート生成ヘルパー ───────────────────────────────────────────────────────
+// ─── 入力区分・書式 ───────────────────────────────────────────────────────────
+
+/**
+ * 入力区分。ヘッダーの3行目に記号を出し、データセルを色で塗り分ける。
+ *
+ * ヘッダー文字列は "field_id\n(日本語名)\n◎必須" になるが、
+ * reader.normalizeKey() は最初の改行までを見るため field_id の解決には影響しない。
+ */
+type InputClass = "required" | "optional" | "auto";
+
+const MARK: Record<InputClass, string> = {
+  required: "◎必須",
+  optional: "○任意",
+  auto: "―自動",
+};
+
+const FILL: Record<InputClass, ExcelJS.FillPattern> = {
+  required: { type: "pattern", pattern: "solid", fgColor: { argb: "FFFFF2CC" } }, // 薄い黄
+  optional: { type: "pattern", pattern: "solid", fgColor: { argb: "FFE2EFDA" } }, // 薄い緑
+  auto: { type: "pattern", pattern: "solid", fgColor: { argb: "FFEDEDED" } },     // 薄い灰
+};
+
+const HEADER_FILL: ExcelJS.FillPattern = {
+  type: "pattern", pattern: "solid", fgColor: { argb: "FF44546A" },
+};
+
+const SECTION_FILL: ExcelJS.FillPattern = {
+  type: "pattern", pattern: "solid", fgColor: { argb: "FFD9E2F3" },
+};
+
+const BORDER: Partial<ExcelJS.Borders> = {
+  top: { style: "thin", color: { argb: "FFBFBFBF" } },
+  left: { style: "thin", color: { argb: "FFBFBFBF" } },
+  bottom: { style: "thin", color: { argb: "FFBFBFBF" } },
+  right: { style: "thin", color: { argb: "FFBFBFBF" } },
+};
+
+/** 列定義: 英名（フィールドID） / 日本語名 / 入力区分 / 列幅 / 選択肢 */
+interface ColumnDef {
+  /** フィールドID。reader が正規化して参照するキー */
+  id: string;
+  /** 日本語名（単位・記号を含む） */
+  ja: string;
+  cls: InputClass;
+  width: number;
+  /** 入力規則（ドロップダウン）に出す選択肢 */
+  list?: readonly string[];
+}
+
+function headerText(c: ColumnDef): string {
+  return `${c.id}\n(${c.ja})\n${MARK[c.cls]}`;
+}
+
+/** 空欄追加行数（利用者が行を足さずに書き込めるようにする） */
+const BLANK_ROWS = { pipe: 12, node: 12, point: 20, case: 8 } as const;
+
+// ─── 選択肢 ───────────────────────────────────────────────────────────────────
+
+const PIPE_TYPE_CODES = [
+  "steel", "ductile_iron", "rcp", "cpcp", "upvc",
+  "pe2", "pe3_pe100", "wdpe",
+  "grp_fw1", "grp_fw2", "grp_fw3", "grp_fw4", "grp_fw5", "gfpe",
+] as const;
+
+const NODE_TYPE_CODES = ["reservoir", "junction", "tank", "pump_node", "valve_node"] as const;
+
+const OPERATION_TYPE_CODES = ["valve_close", "valve_open", "pump_stop", "pump_start", "combined"] as const;
+
+const PIPE_TYPE_LABELS: ReadonlyArray<readonly [string, string, string]> = [
+  ["steel", "鋼管", "Steel pipe"],
+  ["ductile_iron", "ダクタイル鋳鉄管", "Ductile iron pipe"],
+  ["rcp", "遠心力鉄筋コンクリート管", "Reinforced concrete pipe (RCP)"],
+  ["cpcp", "コア式PCCP管", "Prestressed concrete cylinder pipe (PCCP)"],
+  ["upvc", "硬質塩ビ管", "Unplasticized PVC pipe (uPVC)"],
+  ["pe2", "一般用PE管（2種）", "Polyethylene pipe, type 2"],
+  ["pe3_pe100", "一般用PE管（3種 PE100）", "Polyethylene pipe, type 3 (PE100)"],
+  ["wdpe", "水道配水用PE管", "PE pipe for water distribution"],
+  ["grp_fw1〜grp_fw5", "FW成形強化プラスチック複合管 1〜5種", "Filament-wound GRP pipe, types 1-5"],
+  ["gfpe", "GF強化ポリエチレン管", "Glass-fibre reinforced PE pipe"],
+];
+
+const NODE_TYPE_LABELS: ReadonlyArray<readonly [string, string, string]> = [
+  ["reservoir", "貯水池・水源（水位固定）", "Reservoir (fixed-head source)"],
+  ["junction", "分岐・接合点", "Junction"],
+  ["tank", "水槽（水位変動）", "Tank (variable level)"],
+  ["pump_node", "ポンプ設置点", "Pump node"],
+  ["valve_node", "バルブ設置点", "Valve node"],
+];
+
+const OPERATION_TYPE_LABELS: ReadonlyArray<readonly [string, string, string]> = [
+  ["valve_close", "バルブ閉そく", "Valve closure"],
+  ["valve_open", "バルブ開操作", "Valve opening"],
+  ["pump_stop", "ポンプ停止", "Pump trip / shutdown"],
+  ["pump_start", "ポンプ起動", "Pump start-up"],
+  ["combined", "複合操作", "Combined operation"],
+];
+
+const STANDARD_IDS = ["nochi_pipeline_2021"] as const;
+const METHOD_IDS = ["joukowsky_v1", "allievi_v1", "moc_v1"] as const;
+
+// ─── 列スキーマ ───────────────────────────────────────────────────────────────
+
+const TABLE_COL: ColumnDef = { id: "テーブル", ja: "表種別・変更不可", cls: "auto", width: 10 };
+
+const PIPE_COLS: readonly ColumnDef[] = [
+  { id: "pipe_id", ja: "管路ID", cls: "required", width: 12 },
+  { id: "pipe_name", ja: "管路名", cls: "optional", width: 14 },
+  { id: "start_node", ja: "始点節点ID", cls: "required", width: 12 },
+  { id: "end_node", ja: "終点節点ID", cls: "required", width: 12 },
+  { id: "pipe_type", ja: "管種コード", cls: "required", width: 15, list: PIPE_TYPE_CODES },
+  { id: "inner_diameter", ja: "管内径 D [m]", cls: "required", width: 14 },
+  { id: "wall_thickness", ja: "管厚 t [m]", cls: "required", width: 13 },
+  { id: "length", ja: "管路延長 L [m]", cls: "required", width: 14 },
+  { id: "roughness_coeff", ja: "粗度係数 C（ヘーゼン・ウィリアムス）", cls: "required", width: 16 },
+  { id: "youngs_modulus", ja: "ヤング係数 Eₛ [kN/m²]・空欄なら管種から自動", cls: "optional", width: 18 },
+  { id: "c1_coeff", ja: "埋設状況係数 C₁・空欄なら 1.0", cls: "optional", width: 16 },
+];
+
+const NODE_COLS: readonly ColumnDef[] = [
+  { id: "node_id", ja: "節点ID", cls: "required", width: 12 },
+  { id: "node_name", ja: "節点名", cls: "optional", width: 14 },
+  { id: "elevation", ja: "地盤高（標高）[m]", cls: "required", width: 15 },
+  { id: "node_type", ja: "節点種別", cls: "required", width: 14, list: NODE_TYPE_CODES },
+  { id: "hydraulic_grade", ja: "動水位 [m]・定常計算で更新", cls: "optional", width: 17 },
+];
+
+const CASE_COLS: readonly ColumnDef[] = [
+  { id: "case_id", ja: "ケースID", cls: "required", width: 12 },
+  { id: "case_name", ja: "ケース名", cls: "required", width: 18 },
+  { id: "description", ja: "説明", cls: "optional", width: 40 },
+  { id: "operation_type", ja: "操作種別", cls: "required", width: 15, list: OPERATION_TYPE_CODES },
+  { id: "target_facility_id", ja: "対象施設ID（バルブ・ポンプ等）", cls: "required", width: 18 },
+  { id: "initial_velocity", ja: "初期流速 V₀ [m/s]", cls: "required", width: 16 },
+  { id: "initial_head", ja: "初期圧力水頭 H₀ [m]", cls: "required", width: 17 },
+  { id: "close_time", ja: "等価閉そく時間 tν [s]・バルブ操作は必須", cls: "optional", width: 18 },
+];
+
+const POINT_COLS: readonly ColumnDef[] = [
+  { id: "point_id", ja: "測点ID", cls: "required", width: 12 },
+  { id: "point_name", ja: "測点名", cls: "optional", width: 14 },
+  { id: "horizontal_distance", ja: "単距離 Lh [m]", cls: "required", width: 14 },
+  { id: "ground_level", ja: "地盤高 GL [m]", cls: "required", width: 14 },
+  { id: "pipe_center_height", ja: "管中心高 FH [m]", cls: "required", width: 15 },
+  { id: "pipe_length", ja: "管長 SL [m]", cls: "required", width: 13 },
+  { id: "flow_rate", ja: "流量 Q [m³/s]", cls: "required", width: 14 },
+  { id: "diameter", ja: "管径 D [m]", cls: "required", width: 13 },
+  { id: "roughness_c", ja: "流速係数 CI（ヘーゼン・ウィリアムス C）", cls: "required", width: 16 },
+  { id: "bend_loss_coeff", ja: "湾曲損失係数 fb・既定 0", cls: "optional", width: 15 },
+  { id: "valve_loss_coeff", ja: "バルブ損失係数 fv・既定 0", cls: "optional", width: 15 },
+  { id: "branch_loss_coeff", ja: "直角分流損失係数 fβ・既定 0", cls: "optional", width: 16 },
+  { id: "other_loss", ja: "その他損失水頭 [m]", cls: "optional", width: 15 },
+];
+
+/** 案件情報シートの行スキーマ（キー・バリュー形式） */
+const META_ROWS: ReadonlyArray<{ id: string; desc: string; cls: InputClass; list?: readonly string[] }> = [
+  { id: "project_name", desc: "案件名 / Project name", cls: "required" },
+  { id: "designer", desc: "設計者名 / Designer", cls: "optional" },
+  { id: "date", desc: "設計年月日 / Design date（YYYY-MM-DD）", cls: "optional" },
+  { id: "standard_id", desc: "採用基準ID / Design standard（既定のまま可）", cls: "optional", list: STANDARD_IDS },
+  { id: "version", desc: "ソフトウェアバージョン / Software version（自動・編集不要）", cls: "auto" },
+  { id: "method_id", desc: "手法識別子 / Calculation method（既定のまま可）", cls: "optional", list: METHOD_IDS },
+  { id: "notes", desc: "備考 / Notes", cls: "optional" },
+];
+
+// ─── 書式ヘルパー ─────────────────────────────────────────────────────────────
+
+function styleHeaderRow(ws: ExcelJS.Worksheet, rowNum: number, cols: readonly ColumnDef[], startCol: number): void {
+  const row = ws.getRow(rowNum);
+  row.height = 46;
+  cols.forEach((_c, i) => {
+    const cell = row.getCell(startCol + i);
+    cell.fill = HEADER_FILL;
+    cell.font = { bold: true, size: 9, color: { argb: "FFFFFFFF" } };
+    cell.alignment = { vertical: "middle", horizontal: "center", wrapText: true };
+    cell.border = BORDER;
+  });
+}
+
+/** データ行（実データ＋空欄行）を入力区分で塗り分け、選択肢列に入力規則を付ける */
+function styleDataBlock(
+  ws: ExcelJS.Worksheet,
+  firstRow: number,
+  lastRow: number,
+  cols: readonly ColumnDef[],
+  startCol: number,
+): void {
+  for (let r = firstRow; r <= lastRow; r++) {
+    const row = ws.getRow(r);
+    cols.forEach((c, i) => {
+      const cell = row.getCell(startCol + i);
+      cell.fill = FILL[c.cls];
+      cell.border = BORDER;
+      cell.alignment = { vertical: "middle" };
+      if (c.cls === "auto") cell.font = { color: { argb: "FF808080" } };
+      if (c.list) {
+        cell.dataValidation = {
+          type: "list",
+          allowBlank: c.cls !== "required",
+          formulae: [`"${c.list.join(",")}"`],
+          showErrorMessage: true,
+          errorStyle: "warning",
+          errorTitle: "入力候補にない値です",
+          error: `「使い方」シートの一覧から選んでください: ${c.list.join(" / ")}`,
+        };
+      }
+    });
+  }
+}
+
+function applyWidths(ws: ExcelJS.Worksheet, cols: readonly ColumnDef[], startCol: number): void {
+  cols.forEach((c, i) => {
+    ws.getColumn(startCol + i).width = c.width;
+  });
+}
+
+function styleSectionTitle(ws: ExcelJS.Worksheet, rowNum: number, span: number): void {
+  const row = ws.getRow(rowNum);
+  row.getCell(1).font = { bold: true, size: 11, color: { argb: "FF1F3864" } };
+  for (let i = 1; i <= span; i++) row.getCell(i).fill = SECTION_FILL;
+}
+
+function blankRows(count: number, width: number): unknown[][] {
+  return Array.from({ length: count }, () => Array.from({ length: width }, () => null));
+}
+
+// ─── シート生成 ───────────────────────────────────────────────────────────────
 
 function addMetaSheet(wb: ExcelJS.Workbook, meta: Partial<ProjectMeta>): ExcelJS.Worksheet {
   const ws = wb.addWorksheet("案件情報");
-  const rows = [
-    ["フィールドID", "値", "説明"],
-    ["project_name", meta.projectName ?? "", "案件名（必須）"],
-    ["designer", meta.designer ?? "", "設計者名"],
-    ["date", meta.date ?? new Date().toISOString().slice(0, 10), "設計年月日"],
-    ["standard_id", meta.standardId ?? "nochi_pipeline_2021", "採用基準ID"],
-    ["version", meta.version ?? PRODUCT_VERSION, "ソフトウェアバージョン（自動）"],
-    ["method_id", meta.methodId ?? "joukowsky_v1", "手法識別子"],
-    ["notes", meta.notes ?? "", "備考"],
-  ];
-  ws.addRows(rows);
+  const values: Record<string, string> = {
+    project_name: meta.projectName ?? "",
+    designer: meta.designer ?? "",
+    date: meta.date ?? new Date().toISOString().slice(0, 10),
+    standard_id: meta.standardId ?? "nochi_pipeline_2021",
+    version: meta.version ?? PRODUCT_VERSION,
+    method_id: meta.methodId ?? "joukowsky_v1",
+    notes: meta.notes ?? "",
+  };
+
+  ws.addRow(["フィールドID", "値", "説明", "入力区分"]);
+  for (const m of META_ROWS) {
+    ws.addRow([m.id, values[m.id] ?? "", m.desc, MARK[m.cls]]);
+  }
+
+  const head = ws.getRow(1);
+  head.height = 20;
+  for (let c = 1; c <= 4; c++) {
+    const cell = head.getCell(c);
+    cell.fill = HEADER_FILL;
+    cell.font = { bold: true, color: { argb: "FFFFFFFF" } };
+    cell.alignment = { vertical: "middle", horizontal: "center" };
+    cell.border = BORDER;
+  }
+
+  // A列（キー）と C・D列（説明・区分）は編集不可。入力欄は B列だけ。
+  META_ROWS.forEach((m, i) => {
+    const row = ws.getRow(i + 2);
+    row.height = 18;
+    for (const c of [1, 3, 4]) {
+      const cell = row.getCell(c);
+      cell.fill = FILL.auto;
+      cell.font = { color: { argb: "FF595959" } };
+      cell.border = BORDER;
+    }
+    row.getCell(4).alignment = { horizontal: "center" };
+
+    const valueCell = row.getCell(2);
+    valueCell.fill = FILL[m.cls];
+    valueCell.border = BORDER;
+    if (m.cls === "auto") valueCell.font = { color: { argb: "FF808080" } };
+    if (m.list) {
+      valueCell.dataValidation = {
+        type: "list",
+        allowBlank: true,
+        formulae: [`"${m.list.join(",")}"`],
+        showErrorMessage: true,
+        errorStyle: "warning",
+        errorTitle: "入力候補にない値です",
+        error: `候補: ${m.list.join(" / ")}`,
+      };
+    }
+  });
+
+  ws.getColumn(1).width = 18;
+  ws.getColumn(2).width = 30;
+  ws.getColumn(3).width = 52;
+  ws.getColumn(4).width = 10;
+  ws.views = [{ state: "frozen", ySplit: 1 }];
   return ws;
 }
 
-function makePipeRows(pipes: Pipe[]): unknown[][] {
-  const header = [
-    "テーブル", "pipe_id\n(管路ID)", "pipe_name\n(管路名)",
-    "start_node\n(始点節点)", "end_node\n(終点節点)", "pipe_type\n(管種コード)",
-    "inner_diameter\n(内径 [m])", "wall_thickness\n(管厚 [m])", "length\n(延長 [m])",
-    "roughness_coeff\n(粗度係数)", "youngs_modulus\n(ヤング係数 [kN/m²])", "c1_coeff\n(埋設状況係数)",
-  ];
-  const dataRows = pipes.map((p) => [
+function addNetworkSheet(wb: ExcelJS.Workbook, pipes: Pipe[], nodes: Node[]): ExcelJS.Worksheet {
+  const ws = wb.addWorksheet("管路・節点");
+
+  const pipeCols = [TABLE_COL, ...PIPE_COLS];
+  const nodeCols = [TABLE_COL, ...NODE_COLS];
+
+  const pipeData = pipes.map((p) => [
     "pipe", p.id, p.name ?? "",
     p.startNodeId, p.endNodeId, p.pipeType,
     p.innerDiameter, p.wallThickness, p.length,
     p.roughnessCoeff, p.youngsModulus ?? "", p.c1Coeff ?? "",
   ]);
-  return [header, ...dataRows];
-}
-
-function makeNodeRows(nodes: Node[]): unknown[][] {
-  const header = [
-    "テーブル", "node_id\n(節点ID)", "node_name\n(節点名)",
-    "elevation\n(標高 [m])", "node_type\n(節点種別)", "hydraulic_grade\n(動水位 [m])",
-  ];
-  const dataRows = nodes.map((n) => [
+  const nodeData = nodes.map((n) => [
     "node", n.id, n.name ?? "",
     n.elevation, n.nodeType, n.hydraulicGrade ?? "",
   ]);
-  return [header, ...dataRows];
-}
 
-function addNetworkSheet(wb: ExcelJS.Workbook, pipes: Pipe[], nodes: Node[]): ExcelJS.Worksheet {
-  const ws = wb.addWorksheet("管路・節点");
-  const rows: unknown[][] = [
-    // --- 管路テーブル ---
-    ["# 管路区間（Pipe）"],
-    ...makePipeRows(pipes),
-    [],
-    // --- 節点テーブル ---
-    ["# 節点（Node）"],
-    ...makeNodeRows(nodes),
-  ];
-  ws.addRows(rows);
+  // reader.parseNetwork() は A列に「節点」を含む行を Node セクションの開始として探すため、
+  // それより前の A列に「節点」の語を置かないこと。
+  ws.addRow(["# 管路区間（Pipe） / Pipe segments"]);
+  const pipeHeaderRow = 2;
+  ws.addRow(pipeCols.map(headerText));
+  const pipeFirst = pipeHeaderRow + 1;
+  for (const r of pipeData) ws.addRow(r);
+  for (const r of blankRows(BLANK_ROWS.pipe, pipeCols.length)) ws.addRow(r);
+  const pipeLast = pipeFirst + pipeData.length + BLANK_ROWS.pipe - 1;
+
+  ws.addRow([]);
+  const nodeTitleRow = pipeLast + 2;
+  ws.addRow(["# 節点（Node） / Nodes"]);
+  const nodeHeaderRow = nodeTitleRow + 1;
+  ws.addRow(nodeCols.map(headerText));
+  const nodeFirst = nodeHeaderRow + 1;
+  for (const r of nodeData) ws.addRow(r);
+  for (const r of blankRows(BLANK_ROWS.node, nodeCols.length)) ws.addRow(r);
+  const nodeLast = nodeFirst + nodeData.length + BLANK_ROWS.node - 1;
+
+  styleSectionTitle(ws, 1, pipeCols.length);
+  styleHeaderRow(ws, pipeHeaderRow, pipeCols, 1);
+  styleDataBlock(ws, pipeFirst, pipeLast, pipeCols, 1);
+
+  styleSectionTitle(ws, nodeTitleRow, nodeCols.length);
+  styleHeaderRow(ws, nodeHeaderRow, nodeCols, 1);
+  styleDataBlock(ws, nodeFirst, nodeLast, nodeCols, 1);
+
+  applyWidths(ws, pipeCols, 1);
   return ws;
 }
 
 function addCasesSheet(wb: ExcelJS.Workbook, cases: CalculationCase[]): ExcelJS.Worksheet {
   const ws = wb.addWorksheet("ケース設定");
-  const header = [
-    "case_id\n(ケースID)", "case_name\n(ケース名)", "description\n(説明)",
-    "operation_type\n(操作種別)", "target_facility_id\n(対象施設ID)",
-    "initial_flow\n(初期流速 V₀ [m/s])", "initial_head\n(初期水頭 H₀ [m])",
-  ];
+  ws.addRow(CASE_COLS.map(headerText));
   const dataRows = cases.map((c) => [
     c.id, c.name, c.description ?? "",
     c.operationType, c.targetFacilityId,
-    c.initialVelocity, c.initialHead,
+    c.initialVelocity, c.initialHead, c.closeTime ?? "",
   ]);
-  ws.addRows([header, ...dataRows]);
+  for (const r of dataRows) ws.addRow(r);
+  for (const r of blankRows(BLANK_ROWS.case, CASE_COLS.length)) ws.addRow(r);
+
+  styleHeaderRow(ws, 1, CASE_COLS, 1);
+  styleDataBlock(ws, 2, 1 + dataRows.length + BLANK_ROWS.case, CASE_COLS, 1);
+  applyWidths(ws, CASE_COLS, 1);
+  ws.views = [{ state: "frozen", ySplit: 1 }];
   return ws;
 }
 
 function addMeasurementPointsSheet(wb: ExcelJS.Workbook, points: MeasurementPoint[]): ExcelJS.Worksheet {
   const ws = wb.addWorksheet("測点データ");
-  const header = [
-    "point_id\n(測点ID)", "point_name\n(測点名)",
-    "horizontal_distance\n(単距離 Lh [m])", "ground_level\n(地盤高 GL [m])", "pipe_center_height\n(管中心高 FH [m])",
-    "pipe_length\n(管長 SL [m])", "flow_rate\n(流量 Q [m³/s])", "diameter\n(管径 D [m])", "roughness_c\n(流速係数 CI)",
-    "bend_loss_coeff\n(湾曲損失係数 fb)", "valve_loss_coeff\n(バルブ損失係数 fv)", "branch_loss_coeff\n(直角分流損失係数 fβ)",
-    "other_loss\n(その他損失 [m])",
-  ];
-
+  ws.addRow(POINT_COLS.map(headerText));
   const dataRows = points.map((pt) => [
     pt.id, pt.name ?? "",
     pt.horizontalDistance, pt.groundLevel, pt.pipeCenterHeight,
@@ -112,60 +387,150 @@ function addMeasurementPointsSheet(wb: ExcelJS.Workbook, points: MeasurementPoin
     pt.bendLossCoeff, pt.valveLossCoeff, pt.branchLossCoeff,
     pt.otherLoss ?? "",
   ]);
+  for (const r of dataRows) ws.addRow(r);
+  for (const r of blankRows(BLANK_ROWS.point, POINT_COLS.length)) ws.addRow(r);
 
-  ws.addRows([header, ...dataRows]);
+  styleHeaderRow(ws, 1, POINT_COLS, 1);
+  styleDataBlock(ws, 2, 1 + dataRows.length + BLANK_ROWS.point, POINT_COLS, 1);
+  applyWidths(ws, POINT_COLS, 1);
+  ws.views = [{ state: "frozen", xSplit: 1, ySplit: 1 }];
   return ws;
 }
 
+// ─── 使い方シート ─────────────────────────────────────────────────────────────
+
+/** 用語対応表: 日本語名 / English / 記号 / 単位 / フィールドID */
+const GLOSSARY: ReadonlyArray<readonly [string, string, string, string, string]> = [
+  ["管内径", "Inner diameter", "D", "m", "inner_diameter / diameter"],
+  ["管厚", "Wall thickness", "t", "m", "wall_thickness"],
+  ["管路延長", "Pipe length", "L", "m", "length"],
+  ["管長（斜距離）", "Slope length", "SL", "m", "pipe_length"],
+  ["単距離（水平距離）", "Horizontal distance", "Lh", "m", "horizontal_distance"],
+  ["地盤高", "Ground level / elevation", "GL", "m", "ground_level / elevation"],
+  ["管中心高", "Pipe centreline elevation", "FH", "m", "pipe_center_height"],
+  ["流量", "Flow rate / discharge", "Q", "m³/s", "flow_rate"],
+  ["流速", "Flow velocity", "V", "m/s", "initial_velocity"],
+  ["初期圧力水頭", "Initial pressure head", "H₀", "m", "initial_head"],
+  ["粗度係数（流速係数）", "Hazen-Williams roughness coefficient", "C, CI", "—", "roughness_coeff / roughness_c"],
+  ["ヤング係数（縦弾性係数）", "Young modulus of pipe material", "Eₛ", "kN/m²", "youngs_modulus"],
+  ["埋設状況係数", "Pipe restraint (anchorage) coefficient", "C₁", "—", "c1_coeff"],
+  ["湾曲損失係数", "Bend loss coefficient", "fb", "—", "bend_loss_coeff"],
+  ["バルブ損失係数", "Valve loss coefficient", "fv", "—", "valve_loss_coeff"],
+  ["直角分流損失係数", "Right-angle branch loss coefficient", "fβ", "—", "branch_loss_coeff"],
+  ["その他損失水頭", "Other minor loss head", "Σhc", "m", "other_loss"],
+  ["動水位", "Hydraulic grade line", "WLm", "m", "hydraulic_grade"],
+  ["波速（圧力波伝播速度）", "Wave speed / celerity", "a", "m/s", "（計算値）"],
+  ["圧力振動周期", "Pressure wave period", "T₀", "s", "（計算値 4L/a）"],
+  ["等価閉そく時間", "Equivalent valve closure time", "tν", "s", "close_time"],
+  ["水撃圧", "Water hammer (surge) pressure", "Pi", "MPa", "（計算値）"],
+  ["静水圧", "Static pressure", "Ps", "MPa", "（計算値）"],
+  ["設計内圧", "Design internal pressure", "Pp", "MPa", "（計算値 Ps+Pi）"],
+];
+
 function addInstructionSheet(wb: ExcelJS.Workbook): ExcelJS.Worksheet {
   const ws = wb.addWorksheet("使い方");
-  const rows = [
-    ["open-waterhammer 入力帳票"],
-    [""],
-    ["■ シート構成"],
-    ["案件情報", "プロジェクト名・採用基準などのメタ情報"],
-    ["管路・節点", "管路区間と節点の諸元（Pipeテーブル・Nodeテーブル）"],
-    ["測点データ", "水理計算書用の測点データ（成果品参照様式）"],
-    ["ケース設定", "計算ケースの一覧（操作種別・初期条件）"],
-    [""],
-    ["■ 管種コード一覧（pipe_type 欄に入力）"],
-    ["steel", "鋼管"],
-    ["ductile_iron", "ダクタイル鋳鉄管"],
-    ["rcp", "遠心力鉄筋コンクリート管"],
-    ["cpcp", "コア式PCCP管"],
-    ["upvc", "硬質塩ビ管"],
-    ["pe2", "一般用PE管（2種）"],
-    ["pe3_pe100", "一般用PE管（3種 PE100）"],
-    ["wdpe", "水道配水用PE管"],
-    ["grp_fw1〜grp_fw5", "FW成形強化プラスチック複合管 1〜5種"],
-    ["gfpe", "GF強化ポリエチレン管"],
-    [""],
-    ["■ 単位"],
-    ["inner_diameter（管内径）", "m"],
-    ["wall_thickness（管厚）", "m"],
-    ["length（管路延長）", "m"],
-    ["initial_flow（初期流速）", "m/s"],
-    ["initial_head（初期圧力水頭）", "m"],
-    [""],
-    [""],
-    ["■ 測点データの入力"],
-    ["測点ID", "測点名称（IP点番号、No等）"],
-    ["単距離 Lh", "前測点からの水平距離 [m]"],
-    ["地盤高 GL", "地盤標高 [m]"],
-    ["管中心高 FH", "管路中心の標高 [m]（= GL - 土被り - D/2）"],
-    ["管長 SL", "実延長（斜距離）[m]"],
-    ["流量 Q", "設計流量 [m³/s]"],
-    ["管径 D", "管内径 [m]"],
-    ["流速係数 CI", "Hazen-Williams 粗度係数 C"],
-    ["湾曲損失係数 fb", "曲管・ベンド部の損失係数 [-]"],
-    ["バルブ損失係数 fv", "バルブ・弁類の損失係数 [-]"],
-    ["直角分流損失係数 fβ", "分水工の損失係数 [-]"],
-    ["その他損失", "上記以外の局部損失水頭 [m]（直接入力）"],
-    [""],
-    ["参照: 土地改良設計基準パイプライン（令和3年6月改訂）"],
-    ["ライセンス: AGPL-3.0-or-later"],
-  ];
-  ws.addRows(rows);
+
+  const push = (row: unknown[]) => ws.addRow(row);
+  const headRows: number[] = [];
+  const head = (text: string) => { push([text]); headRows.push(ws.rowCount); };
+
+  push(["open-waterhammer 入力帳票 / Water hammer analysis input workbook"]);
+  ws.getRow(1).font = { bold: true, size: 14, color: { argb: "FF1F3864" } };
+  push([]);
+
+  head("■ 色の意味（入力するセルの見分け方） / Legend");
+  push(["◎必須", "必ず入力してください", "Required — must be filled in"]);
+  const legendRequired = ws.rowCount;
+  push(["○任意", "空欄でも計算できます（既定値・自動補完が入ります）", "Optional — a default is used when blank"]);
+  const legendOptional = ws.rowCount;
+  push(["―自動", "編集不要。ソフトが書き込む欄・表の構造を決める欄です", "Auto / fixed — do not edit"]);
+  const legendAuto = ws.rowCount;
+  push(["（濃紺の行）", "見出し行。文字を書き換えると読み込めなくなります", "Header row — do not rename"]);
+  const legendHeader = ws.rowCount;
+  push([]);
+  push(["※ 各シートの見出しは「フィールドID（英名）／日本語名／入力区分」の3段で表示しています。"]);
+  push(["※ 見出しの英名はソフトが列を見分けるキーです。日本語名だけを書き換えることはできません。"]);
+  push([]);
+
+  head("■ シート構成 / Sheets");
+  push(["案件情報", "プロジェクト名・採用基準などのメタ情報", "Project metadata"]);
+  push(["管路・節点", "管路区間と節点の諸元（Pipeテーブル・Nodeテーブル）", "Pipes and nodes"]);
+  push(["測点データ", "水理計算書用の測点データ（成果品参照様式）", "Measurement points for the hydraulic calculation sheet"]);
+  push(["ケース設定", "計算ケースの一覧（操作種別・初期条件）", "Calculation cases"]);
+  push([]);
+
+  head("■ 管種コード / Pipe material codes（pipe_type 欄）");
+  push(["コード", "日本語名", "English"]);
+  for (const r of PIPE_TYPE_LABELS) push([...r]);
+  push([]);
+
+  head("■ 節点種別コード / Node type codes（node_type 欄）");
+  push(["コード", "日本語名", "English"]);
+  for (const r of NODE_TYPE_LABELS) push([...r]);
+  push([]);
+
+  head("■ 操作種別コード / Operation type codes（operation_type 欄）");
+  push(["コード", "日本語名", "English"]);
+  for (const r of OPERATION_TYPE_LABELS) push([...r]);
+  push([]);
+
+  head("■ 用語対応表 / Glossary");
+  push(["日本語名", "English", "記号", "単位", "フィールドID"]);
+  const glossaryHeaderRow = ws.rowCount;
+  for (const r of GLOSSARY) push([...r]);
+  push([]);
+
+  head("■ ケース設定の入力について / Notes on calculation cases");
+  push(["等価閉そく時間 tν", "バルブ操作ケース（valve_close / valve_open）では必ず入力してください。"]);
+  push(["", "急閉そく・緩閉そくの判定と、アリエビ式の適用可否（tν > L/300）に使います。"]);
+  push(["", "ポンプ操作ケースでは不要です。"]);
+  push(["対象施設ID", "操作するバルブ・ポンプのIDです。"]);
+  push([]);
+
+  head("■ 表への行の追加について / Adding rows");
+  push(["行の追加", "各表の下に空欄行を用意しています。足りないときは行を挿入してください。"]);
+  push(["空行", "表の途中に空行があっても、その先の行まで読み込みます。"]);
+  push([]);
+
+  head("■ 測点データの入力について / Notes on measurement points");
+  push(["管中心高 FH", "管路中心の標高 [m]（= GL − 土被り − D/2）"]);
+  push(["管長 SL", "実延長（斜距離）[m]。単距離 Lh は水平距離"]);
+  push(["損失係数 fb / fv / fβ", "無次元 [-]。速度水頭 hv に乗じて損失水頭になります"]);
+  push(["その他損失", "上記以外の局部損失水頭 [m]（係数ではなく水頭を直接入力）"]);
+  push([]);
+
+  push(["参照: 土地改良事業計画設計基準 設計「パイプライン」技術書（令和3年6月改訂）"]);
+  push(["ライセンス: AGPL-3.0-or-later"]);
+
+  for (const r of headRows) {
+    const row = ws.getRow(r);
+    row.getCell(1).font = { bold: true, size: 11, color: { argb: "FF1F3864" } };
+    for (let c = 1; c <= 5; c++) row.getCell(c).fill = SECTION_FILL;
+  }
+
+  ws.getRow(legendRequired).getCell(1).fill = FILL.required;
+  ws.getRow(legendOptional).getCell(1).fill = FILL.optional;
+  ws.getRow(legendAuto).getCell(1).fill = FILL.auto;
+  const headerSample = ws.getRow(legendHeader).getCell(1);
+  headerSample.fill = HEADER_FILL;
+  headerSample.font = { bold: true, color: { argb: "FFFFFFFF" } };
+  for (const r of [legendRequired, legendOptional, legendAuto, legendHeader]) {
+    const cell = ws.getRow(r).getCell(1);
+    cell.alignment = { horizontal: "center" };
+    cell.border = BORDER;
+  }
+
+  const glossaryHead = ws.getRow(glossaryHeaderRow);
+  for (let c = 1; c <= 5; c++) {
+    glossaryHead.getCell(c).font = { bold: true };
+    glossaryHead.getCell(c).border = BORDER;
+  }
+
+  ws.getColumn(1).width = 26;
+  ws.getColumn(2).width = 46;
+  ws.getColumn(3).width = 44;
+  ws.getColumn(4).width = 10;
+  ws.getColumn(5).width = 30;
   return ws;
 }
 

--- a/packages/sample-data/src/demo-case-01.ts
+++ b/packages/sample-data/src/demo-case-01.ts
@@ -10,7 +10,7 @@
  * Excelテンプレート（demo-case-01.xlsx）としてもダウンロード可能。
  */
 
-import type { Pipe, CalculationCase } from "@open-waterhammer/core";
+import type { Pipe, Node, CalculationCase } from "@open-waterhammer/core";
 
 export const DEMO_CASE_01_PIPE: Pipe = {
   id: "pipe-01",
@@ -26,6 +26,18 @@ export const DEMO_CASE_01_PIPE: Pipe = {
   // c1Coeff: デフォルト 1.0
 };
 
+/**
+ * 節点。末端バルブ（N2）を標高 0 m の基準にとり、上流水槽（N1）の水面を
+ * 標高 30 m に置くことで、バルブ位置の静水頭が H₀ = 30 m と一致する。
+ */
+export const DEMO_CASE_01_NODES: Node[] = [
+  { id: "N1", name: "上流水槽", elevation: 30.0, nodeType: "reservoir", hydraulicGrade: 30.0 },
+  { id: "N2", name: "末端バルブ", elevation: 0.0, nodeType: "valve_node" },
+];
+
+/** バルブ等価閉そく時間 [s] */
+export const DEMO_CASE_01_CLOSE_TIME = 0.5;
+
 export const DEMO_CASE_01_CASE: CalculationCase = {
   id: "case-01",
   name: "バルブ急閉そく",
@@ -34,10 +46,8 @@ export const DEMO_CASE_01_CASE: CalculationCase = {
   targetFacilityId: "valve-01",
   initialVelocity: 1.0,   // V₀ = 1.0 m/s
   initialHead: 30.0,      // H₀ = 30.0 m（静水頭）
+  closeTime: DEMO_CASE_01_CLOSE_TIME,
 };
-
-/** バルブ等価閉そく時間 [s] */
-export const DEMO_CASE_01_CLOSE_TIME = 0.5;
 
 export const DEMO_CASE_01_DESCRIPTION = `
 デモケース 01: バルブ急閉そく（農業用パイプライン）

--- a/packages/sample-data/src/demo-case-02.ts
+++ b/packages/sample-data/src/demo-case-02.ts
@@ -19,6 +19,9 @@ export const DEMO_CASE_02_PIPE: Pipe = {
   roughnessCoeff: 130,
 };
 
+/** バルブ等価閉そく時間 [s]（急閉そくより十分に長い） */
+export const DEMO_CASE_02_CLOSE_TIME = 10.0;
+
 export const DEMO_CASE_02_CASE: CalculationCase = {
   id: "case-02",
   name: "バルブ緩閉そく",
@@ -27,10 +30,8 @@ export const DEMO_CASE_02_CASE: CalculationCase = {
   targetFacilityId: "valve-01",
   initialVelocity: 1.0,
   initialHead: 30.0,
+  closeTime: DEMO_CASE_02_CLOSE_TIME,
 };
-
-/** バルブ等価閉そく時間 [s]（急閉そくより十分に長い） */
-export const DEMO_CASE_02_CLOSE_TIME = 10.0;
 
 export const DEMO_CASE_02_DESCRIPTION = `
 デモケース 02: バルブ緩閉そく（アリエビ式）


### PR DESCRIPTION
## 目的

入力用 Excel（`generateTemplate`）について、**どのセルを埋めればよいのかが開いた瞬間に分からない**という指摘に対応する。あわせて、その調査中に見つかった読み書きの取りこぼしをふさぐ。

## 1. 入力欄の可視化

見出しを3段にした。

```
initial_velocity
(初期流速 V₀ [m/s])
◎必須
```

`reader.normalizeKey()` は最初の改行までしか見ないため、表示を増やしても列の解決には影響しない。

データセルは入力区分で塗り分けた。

| 記号 | 色 | 意味 |
|---|---|---|
| ◎必須 | 薄い黄 | 未入力だとエラー |
| ○任意 | 薄い緑 | 空欄なら既定値・自動補完（`youngs_modulus` は管種から、`c1_coeff` は 1.0、損失係数は 0） |
| ―自動 | 薄い灰 | `version` や `テーブル` 列など、編集不要 |
| （見出し） | 濃紺 | 書き換えると読み込めなくなる |

- `pipe_type` / `node_type` / `operation_type` / `standard_id` / `method_id` にドロップダウン（入力規則）
- 「使い方」シートに凡例、**節点種別・操作種別の日英対応表**（これまでどこにも記載がなかった）、**用語対応表**（日本語／English／記号／単位／フィールドID）
- 見出し行の固定、列幅、行追加用の空欄行

## 2. フィールドIDの誤称を修正

`initial_flow` → **`initial_velocity`**。値は 1.0 m/s の**流速**で、ドメイン型も `initialVelocity`。`flow` は流量（m³/s）を指すので誤り。旧IDは既存ブックのため読み取りだけ残している。

## 3. 取りこぼしの修正

| # | 内容 |
|---|---|
| 1 | **等価閉そく時間 tν を入力できなかった。** ケース設定に `close_time` 列を追加し、`CalculationCase.closeTime` として読み取り、`excel-import` 経由でシナリオの `eventSettings` に渡す。デモの case-02「緩閉そく（アリエビ式）」が Excel だけで完結するようになった。未入力のバルブ操作ケースには警告を出す |
| 2 | **節点テーブルが空のままダウンロードされていた**（`nodes: []`）。`DEMO_CASE_01_NODES` を追加して同梱。末端バルブ N2 を標高 0 m、上流水槽 N1 の水面を 30 m に置き、H₀ = 30 m と整合させている |
| 3 | **表の途中に空行があると、以降の行が黙って読み飛ばされていた。** セクション見出し（`# ...`）まで読み進めるようにした |
| 4 | **エラーの行番号がずれていた。** 実際のシート行番号を各行に持たせて表示する |
| 5 | **仕様書の管種コード表が実装と食い違っていた。** `wdpe1`〜`wdpe5` に GRP FW の Eₛ（21.6/19.6/16.7/15.2/14.7）が入っていた誤記を訂正し、`pipe-materials.ts` の値に合わせた |
| 6 | 節点 `elevation` の表示名が帳票「標高」／仕様書・reader「地盤高」で不一致だった。「地盤高（標高）」に統一 |

## 検証

- `excel-io` 25件、`core` 156件、`web-free` の Excel 関連 25件が通過
- 生成 → 読み込みの往復でデータの欠落なし（管路・節点・ケース・測点31点、tν 0.5/10.0 を含む）
- 表の途中に空行を挟んだブックで、空行の先の管路・測点が読み込まれることを確認

## 補足

`apps/web-free/src/workspace/workspace-context.tsx` の `importExcelInputs`（`eventSettings` 引数の追加）は、作業中に別セッションのコミット cb5f4ae に取り込まれたため、この PR の差分には含まれていません。

## 残件（この PR では未着手）

技術用語ではなく変数名になっているフィールドIDが残っています。reader・仕様書・テスト・サンプルデータに波及するため分離しました。

- `c1_coeff` → `pipe_restraint_coeff`（埋設状況係数）
- `roughness_coeff` / `roughness_c` → `hazen_williams_c` に統一（同じ量が2つの名前）
- `other_loss` → `other_minor_loss_head`（係数ではなく水頭 [m]）
- `target_facility_id` → `target_device_id`
- `pipe_type` → `pipe_material`（実体は管材）
- `diameter` / `inner_diameter`、`pipe_length` / `length` の重複整理

🤖 Generated with [Claude Code](https://claude.com/claude-code)
