### PR TITLE
帳票のフィールドIDを技術用語に統一する

### DIFF
--- a/apps/web-free/src/workspace/tabs/__tests__/ExcelIoCard.test.tsx
+++ b/apps/web-free/src/workspace/tabs/__tests__/ExcelIoCard.test.tsx
@@ -55,7 +55,7 @@ describe('ExcelIoCard', () => {
     const user = userEvent.setup()
     mockedParseWorkbook.mockResolvedValueOnce({
       data: { meta: { projectName: '', standardId: '' }, pipes: [], nodes: [], cases: [], measurementPoints: [] },
-      errors: [{ sheet: 'network', row: 3, field: 'pipe_type', message: '不明な管種コード: "foo"' }],
+      errors: [{ sheet: 'network', row: 3, field: 'pipe_material', message: '不明な管種コード: "foo"' }],
       warnings: [],
     })
     const { repository } = setup()

--- a/docs/excel-template-spec.md
+++ b/docs/excel-template-spec.md
@@ -68,13 +68,13 @@
 | `pipe_name` | 管路名 | string | — | — | |
 | `start_node` | 始点節点ID | string | — | ○ | |
 | `end_node` | 終点節点ID | string | — | ○ | |
-| `pipe_type` | 管種 | enum | — | ○ | 下記管種コード参照 |
+| `pipe_material` | 管種（管材） | enum | — | ○ | 下記管種コード参照。旧ID `pipe_type` |
 | `inner_diameter` | 管内径 D | float | m | ○ | 波速計算に使用 |
 | `wall_thickness` | 管厚 t | float | m | ○ | 波速計算に使用 |
 | `length` | 管路延長 L | float | m | ○ | |
-| `roughness_coeff` | 粗度係数 | float | — | ○ | ハーゼン・ウィリアムスCまたはマニング n |
+| `hazen_williams_c` | 粗度係数 C | float | — | ○ | ハーゼン・ウィリアムス C。実装は常に HW（`moc.ts` で Darcy 等価に換算）。旧ID `roughness_coeff` |
 | `youngs_modulus` | ヤング係数 Eₛ | float | kN/m² | — | 管種から自動参照（上書き可） |
-| `c1_coeff` | 埋設状況係数 C₁ | float | — | — | デフォルト: 1.0 |
+| `pipe_restraint_coeff` | 埋設状況係数 C₁ | float | — | — | デフォルト: 1.0。旧ID `c1_coeff` |
 
 ##### 管種コード（参照: 表-8.2.1）
 
@@ -147,7 +147,7 @@
 | `case_name` | ケース名 | string | ○ | |
 | `description` | 説明 | string | — | |
 | `operation_type` | 操作種別 | enum | ○ | `valve_close`, `valve_open`, `pump_stop`, `pump_start`, `combined` |
-| `target_facility_id` | 対象施設ID | string | ○ | |
+| `target_device_id` | 対象施設ID（バルブ・ポンプ等） | string | ○ | 旧ID `target_facility_id` |
 | `initial_velocity` | 初期流速 V₀ | float | ○ | m/s。旧ID `initial_flow`（流速なのに flow という誤称）も読み取りのみ受け付ける |
 | `initial_head` | 初期圧力水頭 H₀ | float | ○ | m |
 | `close_time` | 等価閉そく時間 tν | float | — | s。`valve_close` / `valve_open` では必須。急緩判定とアリエビ式に使う |

--- a/docs/standards-mapping.md
+++ b/docs/standards-mapping.md
@@ -60,7 +60,7 @@ primary_chapter: "8. 非定常的な水理現象の解析"
 | `design_pressure` | 設計水圧 | 静水圧 + 水撃圧 | MPa |
 | `static_head` | 静水圧水頭 (H₀) | バルブ位置における静水頭 | m |
 | `alpha_value` | α値 | t₀/T₀ による基礎式適用判定値 | — |
-| `c1_coeff` | 埋設状況係数 (C₁) | 管の埋設条件による係数 | — |
+| `pipe_restraint_coeff` | 埋設状況係数 (C₁) | 管の埋設条件による係数。旧ID `c1_coeff` | — |
 | `youngs_modulus_short` | 短期ヤング係数 (Eₛ) | 管材の短期弾性係数 | kN/m² |
 
 ---

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -35,7 +35,7 @@ export interface Pipe {
   wallThickness: number;
   /** 管路延長 L [m] */
   length: number;
-  /** 粗度係数 (ハーゼン・ウィリアムス C または マニング n) */
+  /** ハーゼン・ウィリアムス粗度係数 C（帳票のフィールドID: hazen_williams_c） */
   roughnessCoeff: number;
   /** ヤング係数 Eₛ [kN/m²] — 省略時は管種から自動参照 */
   youngsModulus?: number;
@@ -141,7 +141,7 @@ export interface MeasurementPoint {
   flowRate: number;
   /** 管径 D [m] (内径) */
   diameter: number;
-  /** 流速係数 CI (Hazen-Williams C) */
+  /** 流速係数 CI = ハーゼン・ウィリアムス C（帳票のフィールドID: hazen_williams_c） */
   roughnessC: number;
   /** 湾曲損失係数 fb [-] */
   bendLossCoeff: number;

--- a/packages/excel-io/src/reader.ts
+++ b/packages/excel-io/src/reader.ts
@@ -155,7 +155,7 @@ function parseMeta(wb: ExcelJS.Workbook, errors: ParseError[]): ProjectMeta {
 
 // ─── network シート（管路・節点） ─────────────────────────────────────────────
 
-const VALID_PIPE_TYPES = new Set<string>([
+const VALID_PIPE_MATERIALS = new Set<string>([
   "steel", "ductile_iron", "rcp", "cpcp", "upvc",
   "pe2", "pe3_pe100", "wdpe",
   "grp_fw1", "grp_fw2", "grp_fw3", "grp_fw4", "grp_fw5", "gfpe",
@@ -174,26 +174,27 @@ function parsePipes(rows: Record<string, unknown>[], errors: ParseError[]): Pipe
     const id = str(row["pipe_id"] ?? row["管路ID"]);
     if (!id) continue; // 空行はスキップ
 
-    const pipeTypeRaw = str(row["pipe_type"] ?? row["管種"]).toLowerCase();
-    if (!VALID_PIPE_TYPES.has(pipeTypeRaw)) {
-      errors.push({ sheet: "network", row: rowNum, field: "pipe_type", message: `不明な管種コード: "${pipeTypeRaw}"` });
+    // 2番目以降のキーは旧フィールドID・日本語見出し（既存の帳票を読むための後方互換）
+    const pipeTypeRaw = str(row["pipe_material"] ?? row["pipe_type"] ?? row["管種"]).toLowerCase();
+    if (!VALID_PIPE_MATERIALS.has(pipeTypeRaw)) {
+      errors.push({ sheet: "network", row: rowNum, field: "pipe_material", message: `不明な管種コード: "${pipeTypeRaw}"` });
     }
 
     const pipe: Pipe = {
       id,
       startNodeId: str(row["start_node"] ?? row["始点節点ID"]),
       endNodeId: str(row["end_node"] ?? row["終点節点ID"]),
-      pipeType: (VALID_PIPE_TYPES.has(pipeTypeRaw) ? pipeTypeRaw : "ductile_iron") as PipeType,
+      pipeType: (VALID_PIPE_MATERIALS.has(pipeTypeRaw) ? pipeTypeRaw : "ductile_iron") as PipeType,
       innerDiameter: requireNum(row["inner_diameter"] ?? row["管内径 D"], "管内径 D", errors, "network", rowNum),
       wallThickness: requireNum(row["wall_thickness"] ?? row["管厚 t"], "管厚 t", errors, "network", rowNum),
       length: requireNum(row["length"] ?? row["管路延長 L"], "管路延長 L", errors, "network", rowNum),
-      roughnessCoeff: requireNum(row["roughness_coeff"] ?? row["粗度係数"], "粗度係数", errors, "network", rowNum),
+      roughnessCoeff: requireNum(row["hazen_williams_c"] ?? row["roughness_coeff"] ?? row["粗度係数"], "粗度係数 C", errors, "network", rowNum),
     };
     const pipeName = str(row["pipe_name"] ?? row["管路名"]);
     if (pipeName) pipe.name = pipeName;
     const Es = num(row["youngs_modulus"] ?? row["ヤング係数 Eₛ"]);
     if (Es !== undefined) pipe.youngsModulus = Es;
-    const c1 = num(row["c1_coeff"] ?? row["埋設状況係数 C₁"]);
+    const c1 = num(row["pipe_restraint_coeff"] ?? row["c1_coeff"] ?? row["埋設状況係数 C₁"]);
     if (c1 !== undefined) pipe.c1Coeff = c1;
     pipes.push(pipe);
   }
@@ -317,7 +318,7 @@ function parseCases(wb: ExcelJS.Workbook, errors: ParseError[], warnings: string
       id,
       name: str(row["case_name"] ?? row["ケース名"]) || id,
       operationType: (VALID_OPERATION_TYPES.has(opRaw) ? opRaw : "valve_close") as OperationType,
-      targetFacilityId: str(row["target_facility_id"] ?? row["対象施設ID"]),
+      targetFacilityId: str(row["target_device_id"] ?? row["target_facility_id"] ?? row["対象施設ID"]),
       // initial_flow は旧フィールドID（流速なのに flow という誤称）。既存ブックのため読み取りだけ残す。
       initialVelocity: requireNum(row["initial_velocity"] ?? row["initial_flow"] ?? row["初期流速 V₀"], "初期流速 V₀", errors, "cases", rowNum),
       initialHead: requireNum(row["initial_head"] ?? row["初期圧力水頭 H₀"], "初期圧力水頭 H₀", errors, "cases", rowNum),
@@ -358,18 +359,18 @@ function parseMeasurementPoints(wb: ExcelJS.Workbook, errors: ParseError[]): Mea
       id,
       horizontalDistance: requireNum(row["horizontal_distance"] ?? row["単距離 Lh"], "単距離", errors, "測点データ", rowNum),
       groundLevel: requireNum(row["ground_level"] ?? row["地盤高 GL"], "地盤高", errors, "測点データ", rowNum),
-      pipeCenterHeight: requireNum(row["pipe_center_height"] ?? row["管中心高 FH"], "管中心高", errors, "測点データ", rowNum),
-      pipeLength: requireNum(row["pipe_length"] ?? row["管長 SL"], "管長", errors, "測点データ", rowNum),
+      pipeCenterHeight: requireNum(row["pipe_centerline_elevation"] ?? row["pipe_center_height"] ?? row["管中心高 FH"], "管中心高", errors, "測点データ", rowNum),
+      pipeLength: requireNum(row["slope_length"] ?? row["pipe_length"] ?? row["管長 SL"], "管長", errors, "測点データ", rowNum),
       flowRate: requireNum(row["flow_rate"] ?? row["流量 Q"], "流量", errors, "測点データ", rowNum),
-      diameter: requireNum(row["diameter"] ?? row["管径 D"], "管径", errors, "測点データ", rowNum),
-      roughnessC: requireNum(row["roughness_c"] ?? row["流速係数 CI"], "流速係数", errors, "測点データ", rowNum),
+      diameter: requireNum(row["inner_diameter"] ?? row["diameter"] ?? row["管径 D"], "管径", errors, "測点データ", rowNum),
+      roughnessC: requireNum(row["hazen_williams_c"] ?? row["roughness_c"] ?? row["流速係数 CI"], "流速係数 C", errors, "測点データ", rowNum),
       bendLossCoeff: num(row["bend_loss_coeff"] ?? row["湾曲損失係数 fb"]) ?? 0,
       valveLossCoeff: num(row["valve_loss_coeff"] ?? row["バルブ損失係数 fv"]) ?? 0,
       branchLossCoeff: num(row["branch_loss_coeff"] ?? row["直角分流損失係数 fβ"]) ?? 0,
     };
     const ptName = str(row["point_name"] ?? row["測点名"]);
     if (ptName) pt.name = ptName;
-    const other = num(row["other_loss"] ?? row["その他損失"]);
+    const other = num(row["other_minor_loss_head"] ?? row["other_loss"] ?? row["その他損失"]);
     if (other !== undefined) pt.otherLoss = other;
     points.push(pt);
   }

--- a/packages/excel-io/src/template.ts
+++ b/packages/excel-io/src/template.ts
@@ -77,7 +77,7 @@ const BLANK_ROWS = { pipe: 12, node: 12, point: 20, case: 8 } as const;
 
 // ─── 選択肢 ───────────────────────────────────────────────────────────────────
 
-const PIPE_TYPE_CODES = [
+const PIPE_MATERIAL_CODES = [
   "steel", "ductile_iron", "rcp", "cpcp", "upvc",
   "pe2", "pe3_pe100", "wdpe",
   "grp_fw1", "grp_fw2", "grp_fw3", "grp_fw4", "grp_fw5", "gfpe",
@@ -87,7 +87,7 @@ const NODE_TYPE_CODES = ["reservoir", "junction", "tank", "pump_node", "valve_no
 
 const OPERATION_TYPE_CODES = ["valve_close", "valve_open", "pump_stop", "pump_start", "combined"] as const;
 
-const PIPE_TYPE_LABELS: ReadonlyArray<readonly [string, string, string]> = [
+const PIPE_MATERIAL_LABELS: ReadonlyArray<readonly [string, string, string]> = [
   ["steel", "鋼管", "Steel pipe"],
   ["ductile_iron", "ダクタイル鋳鉄管", "Ductile iron pipe"],
   ["rcp", "遠心力鉄筋コンクリート管", "Reinforced concrete pipe (RCP)"],
@@ -128,13 +128,13 @@ const PIPE_COLS: readonly ColumnDef[] = [
   { id: "pipe_name", ja: "管路名", cls: "optional", width: 14 },
   { id: "start_node", ja: "始点節点ID", cls: "required", width: 12 },
   { id: "end_node", ja: "終点節点ID", cls: "required", width: 12 },
-  { id: "pipe_type", ja: "管種コード", cls: "required", width: 15, list: PIPE_TYPE_CODES },
+  { id: "pipe_material", ja: "管種コード", cls: "required", width: 15, list: PIPE_MATERIAL_CODES },
   { id: "inner_diameter", ja: "管内径 D [m]", cls: "required", width: 14 },
   { id: "wall_thickness", ja: "管厚 t [m]", cls: "required", width: 13 },
   { id: "length", ja: "管路延長 L [m]", cls: "required", width: 14 },
-  { id: "roughness_coeff", ja: "粗度係数 C（ヘーゼン・ウィリアムス）", cls: "required", width: 16 },
+  { id: "hazen_williams_c", ja: "粗度係数 C（ヘーゼン・ウィリアムス）", cls: "required", width: 16 },
   { id: "youngs_modulus", ja: "ヤング係数 Eₛ [kN/m²]・空欄なら管種から自動", cls: "optional", width: 18 },
-  { id: "c1_coeff", ja: "埋設状況係数 C₁・空欄なら 1.0", cls: "optional", width: 16 },
+  { id: "pipe_restraint_coeff", ja: "埋設状況係数 C₁・空欄なら 1.0", cls: "optional", width: 18 },
 ];
 
 const NODE_COLS: readonly ColumnDef[] = [
@@ -150,7 +150,7 @@ const CASE_COLS: readonly ColumnDef[] = [
   { id: "case_name", ja: "ケース名", cls: "required", width: 18 },
   { id: "description", ja: "説明", cls: "optional", width: 40 },
   { id: "operation_type", ja: "操作種別", cls: "required", width: 15, list: OPERATION_TYPE_CODES },
-  { id: "target_facility_id", ja: "対象施設ID（バルブ・ポンプ等）", cls: "required", width: 18 },
+  { id: "target_device_id", ja: "対象施設ID（バルブ・ポンプ等）", cls: "required", width: 18 },
   { id: "initial_velocity", ja: "初期流速 V₀ [m/s]", cls: "required", width: 16 },
   { id: "initial_head", ja: "初期圧力水頭 H₀ [m]", cls: "required", width: 17 },
   { id: "close_time", ja: "等価閉そく時間 tν [s]・バルブ操作は必須", cls: "optional", width: 18 },
@@ -161,15 +161,15 @@ const POINT_COLS: readonly ColumnDef[] = [
   { id: "point_name", ja: "測点名", cls: "optional", width: 14 },
   { id: "horizontal_distance", ja: "単距離 Lh [m]", cls: "required", width: 14 },
   { id: "ground_level", ja: "地盤高 GL [m]", cls: "required", width: 14 },
-  { id: "pipe_center_height", ja: "管中心高 FH [m]", cls: "required", width: 15 },
-  { id: "pipe_length", ja: "管長 SL [m]", cls: "required", width: 13 },
+  { id: "pipe_centerline_elevation", ja: "管中心高 FH [m]", cls: "required", width: 17 },
+  { id: "slope_length", ja: "管長 SL [m]（斜距離）", cls: "required", width: 14 },
   { id: "flow_rate", ja: "流量 Q [m³/s]", cls: "required", width: 14 },
-  { id: "diameter", ja: "管径 D [m]", cls: "required", width: 13 },
-  { id: "roughness_c", ja: "流速係数 CI（ヘーゼン・ウィリアムス C）", cls: "required", width: 16 },
+  { id: "inner_diameter", ja: "管径 D [m]（内径）", cls: "required", width: 14 },
+  { id: "hazen_williams_c", ja: "流速係数 CI（ヘーゼン・ウィリアムス C）", cls: "required", width: 16 },
   { id: "bend_loss_coeff", ja: "湾曲損失係数 fb・既定 0", cls: "optional", width: 15 },
   { id: "valve_loss_coeff", ja: "バルブ損失係数 fv・既定 0", cls: "optional", width: 15 },
   { id: "branch_loss_coeff", ja: "直角分流損失係数 fβ・既定 0", cls: "optional", width: 16 },
-  { id: "other_loss", ja: "その他損失水頭 [m]", cls: "optional", width: 15 },
+  { id: "other_minor_loss_head", ja: "その他損失水頭 [m]", cls: "optional", width: 18 },
 ];
 
 /** 案件情報シートの行スキーマ（キー・バリュー形式） */
@@ -401,23 +401,24 @@ function addMeasurementPointsSheet(wb: ExcelJS.Workbook, points: MeasurementPoin
 
 /** 用語対応表: 日本語名 / English / 記号 / 単位 / フィールドID */
 const GLOSSARY: ReadonlyArray<readonly [string, string, string, string, string]> = [
-  ["管内径", "Inner diameter", "D", "m", "inner_diameter / diameter"],
+  ["管種（管材）", "Pipe material", "—", "—", "pipe_material"],
+  ["管内径", "Inner diameter", "D", "m", "inner_diameter"],
   ["管厚", "Wall thickness", "t", "m", "wall_thickness"],
   ["管路延長", "Pipe length", "L", "m", "length"],
-  ["管長（斜距離）", "Slope length", "SL", "m", "pipe_length"],
+  ["管長（斜距離）", "Slope length", "SL", "m", "slope_length"],
   ["単距離（水平距離）", "Horizontal distance", "Lh", "m", "horizontal_distance"],
   ["地盤高", "Ground level / elevation", "GL", "m", "ground_level / elevation"],
-  ["管中心高", "Pipe centreline elevation", "FH", "m", "pipe_center_height"],
+  ["管中心高", "Pipe centreline elevation", "FH", "m", "pipe_centerline_elevation"],
   ["流量", "Flow rate / discharge", "Q", "m³/s", "flow_rate"],
   ["流速", "Flow velocity", "V", "m/s", "initial_velocity"],
   ["初期圧力水頭", "Initial pressure head", "H₀", "m", "initial_head"],
-  ["粗度係数（流速係数）", "Hazen-Williams roughness coefficient", "C, CI", "—", "roughness_coeff / roughness_c"],
+  ["粗度係数（流速係数）", "Hazen-Williams roughness coefficient", "C, CI", "—", "hazen_williams_c"],
   ["ヤング係数（縦弾性係数）", "Young modulus of pipe material", "Eₛ", "kN/m²", "youngs_modulus"],
-  ["埋設状況係数", "Pipe restraint (anchorage) coefficient", "C₁", "—", "c1_coeff"],
+  ["埋設状況係数", "Pipe restraint (anchorage) coefficient", "C₁", "—", "pipe_restraint_coeff"],
   ["湾曲損失係数", "Bend loss coefficient", "fb", "—", "bend_loss_coeff"],
   ["バルブ損失係数", "Valve loss coefficient", "fv", "—", "valve_loss_coeff"],
   ["直角分流損失係数", "Right-angle branch loss coefficient", "fβ", "—", "branch_loss_coeff"],
-  ["その他損失水頭", "Other minor loss head", "Σhc", "m", "other_loss"],
+  ["その他損失水頭", "Other minor loss head", "Σhc", "m", "other_minor_loss_head"],
   ["動水位", "Hydraulic grade line", "WLm", "m", "hydraulic_grade"],
   ["波速（圧力波伝播速度）", "Wave speed / celerity", "a", "m/s", "（計算値）"],
   ["圧力振動周期", "Pressure wave period", "T₀", "s", "（計算値 4L/a）"],
@@ -425,6 +426,23 @@ const GLOSSARY: ReadonlyArray<readonly [string, string, string, string, string]>
   ["水撃圧", "Water hammer (surge) pressure", "Pi", "MPa", "（計算値）"],
   ["静水圧", "Static pressure", "Ps", "MPa", "（計算値）"],
   ["設計内圧", "Design internal pressure", "Pp", "MPa", "（計算値 Ps+Pi）"],
+];
+
+/**
+ * 旧フィールドIDとの対応。
+ * reader は旧IDも読み取るため、既存の帳票はそのまま使える。
+ */
+const RENAMED_FIELD_IDS: ReadonlyArray<readonly [string, string, string]> = [
+  ["initial_flow", "initial_velocity", "値は流速 [m/s]。flow は流量を指すため誤り"],
+  ["pipe_type", "pipe_material", "選ぶのは管の材質（管種）"],
+  ["roughness_coeff", "hazen_williams_c", "ヘーゼン・ウィリアムス C であることを明示"],
+  ["roughness_c", "hazen_williams_c", "管路表と同じ量なので名前をそろえた"],
+  ["c1_coeff", "pipe_restraint_coeff", "記号 C₁ ではなく意味（埋設状況）で示す"],
+  ["target_facility_id", "target_device_id", "対象はバルブ・ポンプなどの機器"],
+  ["diameter", "inner_diameter", "管路表と同じ量なので名前をそろえた"],
+  ["pipe_length", "slope_length", "管路延長 length と別物（斜距離）と分かるように"],
+  ["pipe_center_height", "pipe_centerline_elevation", "標高は elevation にそろえた"],
+  ["other_loss", "other_minor_loss_head", "係数ではなく水頭 [m]"],
 ];
 
 function addInstructionSheet(wb: ExcelJS.Workbook): ExcelJS.Worksheet {
@@ -459,9 +477,9 @@ function addInstructionSheet(wb: ExcelJS.Workbook): ExcelJS.Worksheet {
   push(["ケース設定", "計算ケースの一覧（操作種別・初期条件）", "Calculation cases"]);
   push([]);
 
-  head("■ 管種コード / Pipe material codes（pipe_type 欄）");
+  head("■ 管種コード / Pipe material codes（pipe_material 欄）");
   push(["コード", "日本語名", "English"]);
-  for (const r of PIPE_TYPE_LABELS) push([...r]);
+  for (const r of PIPE_MATERIAL_LABELS) push([...r]);
   push([]);
 
   head("■ 節点種別コード / Node type codes（node_type 欄）");
@@ -478,6 +496,12 @@ function addInstructionSheet(wb: ExcelJS.Workbook): ExcelJS.Worksheet {
   push(["日本語名", "English", "記号", "単位", "フィールドID"]);
   const glossaryHeaderRow = ws.rowCount;
   for (const r of GLOSSARY) push([...r]);
+  push([]);
+
+  head("■ 旧フィールドIDとの対応 / Renamed field IDs");
+  push(["旧ID", "現行ID", "変更の理由"]);
+  for (const [oldId, newId, why] of RENAMED_FIELD_IDS) push([oldId, newId, why]);
+  push(["", "旧IDの帳票もそのまま読み込めます。", "Workbooks using the old IDs are still accepted."]);
   push([]);
 
   head("■ ケース設定の入力について / Notes on calculation cases");


### PR DESCRIPTION
> **#4 の上に積んでいます。** ベースは `feature/excel-input-template-guidance`。#4 をマージすると、この PR は自動で master に付け替わります。

## 目的

入力帳票のフィールドIDに、変数名や記号をそのまま英語にしただけの列が残っている。#4 で残件として挙げたものを一括で改める。

**対象は帳票（Excel）のフィールドIDのみ。** ドメイン型のプロパティ名（`roughnessCoeff` など）と core-py 側の名前は変更していない。reader が両者を橋渡ししているので、影響は帳票の見出しと reader のキーに閉じる。

## リネーム一覧

| 旧ID | 現行ID | 理由 |
|---|---|---|
| `pipe_type` | `pipe_material` | 選ぶのは管の材質（管種）。`type` は接続形態と紛れる |
| `roughness_coeff` | `hazen_williams_c` | ヘーゼン・ウィリアムス C であることを明示 |
| `roughness_c` | `hazen_williams_c` | 管路表と同じ量が2つの名前になっていた |
| `c1_coeff` | `pipe_restraint_coeff` | 記号 C₁ をなぞっただけで、"coeff coeff" と重複もしていた |
| `target_facility_id` | `target_device_id` | 対象はバルブ・ポンプなどの機器 |
| `diameter` | `inner_diameter` | 管路表と同じ量が2つの名前になっていた |
| `pipe_length` | `slope_length` | 管路延長 `length` と別物（斜距離）だと分かるように |
| `pipe_center_height` | `pipe_centerline_elevation` | 標高は `elevation` にそろえた |
| `other_loss` | `other_minor_loss_head` | 係数ではなく水頭 [m] |

## 後方互換

reader は旧IDも読み取ります。**既存の帳票はそのまま使えます。**

```ts
row["hazen_williams_c"] ?? row["roughness_coeff"] ?? row["粗度係数"]
```

「使い方」シートに旧ID対応表を追加しました。

## ついでの訂正

`Pipe.roughnessCoeff` の型コメント「ハーゼン・ウィリアムス C または マニング n」は誤りでした。実装は常に HW C として扱っています（`moc.ts:577` で `C_hw` に分解し、`localDarcyF()` で Darcy 等価に換算。`longitudinal-hydraulic.ts:67` も HW 式）。マニングは使われていません。コメントを実装に合わせました。

## 検証

- `excel-io` 25件、`core` 156件、`web-free` の Excel 関連 25件が通過
- 現行IDの帳票が往復でデータ欠落なし
- **旧IDだけで書いた帳票をエラー0件で読み込めることを実測**（`pipe_type` / `roughness_coeff` / `c1_coeff` / `target_facility_id` / `initial_flow` / `diameter` / `roughness_c` / `pipe_length` / `pipe_center_height` / `other_loss` を全部使った帳票で、C₁=1.2、その他損失=1.5 まで正しく取得）
- 不正な管種コードのエラーが `field: "pipe_material"` で返ることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)
