### PR TITLE
Buffer 回帰テストが待ち時間の中で exceljs を読み込まないようにする

### DIFF
--- a/apps/web-free/src/workspace/tabs/__tests__/ExcelIoCard.buffer-regression.test.tsx
+++ b/apps/web-free/src/workspace/tabs/__tests__/ExcelIoCard.buffer-regression.test.tsx
@@ -1,7 +1,7 @@
 import { InMemoryWorkspaceRepository } from '@open-waterhammer/workspace'
 import { render, screen } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
-import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest'
+import { afterEach, beforeAll, beforeEach, describe, expect, test, vi } from 'vitest'
 
 import { buildSampleWorkspace } from '../../sample-workspace'
 import { WorkspaceProvider } from '../../workspace-context'
@@ -31,8 +31,29 @@ function setup() {
   )
 }
 
+const EMPTY_TEMPLATE = { meta: { projectName: 'buffer-regression' }, pipes: [], nodes: [], cases: [], measurementPoints: [] }
+
 describe('ExcelIoCard template download without a pre-existing globalThis.Buffer', () => {
   let originalBuffer: unknown
+
+  /**
+   * Load the heavy dynamic imports up front, while `Buffer` still exists.
+   *
+   * `downloadTemplate()` calls `import('@open-waterhammer/excel-io')` at click time. Under Vitest
+   * that first load also transforms exceljs plus the excel-io/core/contracts sources, measured here
+   * at ~6.3s — against ~60ms for `generateTemplate()` itself and ~1ms for the Blob. Leaving that
+   * inside the assertion window made the test measure "how fast can Vitest load exceljs", which is
+   * a property of the machine, not of the code: it passed on CI (Linux) and timed out locally.
+   *
+   * Warming the module here does not weaken the regression. exceljs reads `Buffer` when it runs,
+   * not when it loads, so a module imported while `Buffer` existed still fails once `Buffer` is
+   * gone. The "reads Buffer at call time" test below pins that assumption in place, so this
+   * warm-up cannot quietly turn the guard into a no-op.
+   */
+  beforeAll(async () => {
+    await import('@open-waterhammer/excel-io')
+    await import('buffer')
+  }, 60_000)
 
   beforeEach(() => {
     const browserGlobal = globalThis as typeof globalThis & { Buffer?: unknown }
@@ -53,10 +74,8 @@ describe('ExcelIoCard template download without a pre-existing globalThis.Buffer
     try {
       setup()
       await user.click(screen.getByRole('button', { name: /テンプレート/ }))
-      // Explicit timeout: this repo's own precedent (WorkspaceApp.test.tsx's findByText calls)
-      // hardens async assertions to 5s because the default ~1s window can starve under
-      // full-suite parallel load even though the underlying behavior is correct (verified
-      // passing reliably, twice, in isolation before this hardening was added).
+      // With the modules warmed in beforeAll, the work left inside this window is the component's
+      // own logic (~100ms). The 5s budget is here to fail a hang, not to assert a speed.
       await vi.waitFor(() => expect(createObjectURL).toHaveBeenCalled(), { timeout: 5_000 })
       const [blob] = createObjectURL.mock.calls[0]!
       expect(blob).toBeInstanceOf(Blob)
@@ -64,5 +83,18 @@ describe('ExcelIoCard template download without a pre-existing globalThis.Buffer
     } finally {
       createObjectURL.mockRestore()
     }
+  })
+
+  /**
+   * Negative control for the beforeAll warm-up.
+   *
+   * The warm-up is only safe while exceljs resolves `Buffer` at call time. Should a future exceljs
+   * capture it at load time instead, the test above would keep passing while guarding nothing —
+   * it would be running against a module that closed over the real `Buffer` before it was deleted.
+   * This test fails first in that case, and says why.
+   */
+  test('exceljs reads Buffer when it runs, not when it loads (keeps the warm-up honest)', async () => {
+    const { generateTemplate } = await import('@open-waterhammer/excel-io')
+    await expect(generateTemplate(EMPTY_TEMPLATE)).rejects.toThrow(/Buffer/)
   })
 })


### PR DESCRIPTION
## 結論から

**Buffer polyfill は壊れていませんでした。** `ExcelIoCard.buffer-regression.test.tsx` が Node 26 のローカルで落ちていたのは、待ち時間の中で exceljs を読み込んでいたためです。

待ち時間の内訳を測ると、こうなっていました。

| 処理 | 時間 |
|---|---|
| `ensureBrowserBuffer()` | 25ms |
| **`import('@open-waterhammer/excel-io')`** | **6319ms** |
| `generateTemplate()` | 60ms |
| Blob 生成 | 1ms |

`downloadTemplate()` はクリック時に excel-io を動的 import します。Vitest ではこの1回目が exceljs と excel-io / core / contracts のソース変換を伴います。それを `waitFor` の5秒に含めていたので、このテストは実質**「Vitest が exceljs を何秒で読めるか」を測っていました**。CI（Linux）では5秒に収まり、手元の Windows では 5.6 秒かかって落ちる。コードではなくマシンの速さの問題です。

テスト内のコメントによれば、以前も既定の約1秒から5秒へ引き上げた経緯があるようです。同じ理由なので、今回は**待ち時間を広げるのではなく、待ち時間から重い処理を追い出しました。**

## 1. 重い動的 import を `beforeAll` へ

`Buffer` がまだある状態で先に読み込みます。待ち時間に残るのはコンポーネントの処理だけ（約100ms）になり、マシンの速さに左右されなくなります。

## 2. 先読みが安全であることを固定する対照テスト

先読みが安全なのは、**exceljs が `Buffer` を「呼び出し時」に見ている間だけ**です。もし将来の exceljs が読み込み時に握るようになると、上のテストは通り続けたまま**何も守らなくなります**（削除済みの `Buffer` ではなく、削除前の本物を閉じ込んだモジュールを相手にすることになるため）。

そこで対照テストを足しました。`Buffer` があるうちに読み込んだモジュールでも、`Buffer` を消せば `ReferenceError: Buffer is not defined` になる、という前提を固定します。前提が崩れたらこちらが先に落ちて理由を示します。

## 検証

- **`ensureBrowserBuffer()` の呼び出しを一時的に外すとテストが落ちる**ことを確認しました。ガードは効いたままです（これが今回いちばん確かめたかった点です）
- Node 26 で **フルスイート 38ファイル / 201テストが通過**
- `npm run typecheck` / `npm run lint:wording` が通過

## 補足

これで手元の Node 26 でも全部通るようになりました。ただしフルスイートを重い状態で回すと、15秒タイムアウトによる不安定な失敗がごくまれに出ます（落ちるテストが回ごとに変わる種類のもので、単独実行では通ります）。本 PR の対象外の、実行環境の負荷によるものです。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
