### PR TITLE
docs: 開発ワークフローと完了判定を AGENTS.md に定める

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,5 +1,46 @@
 # Repository instructions
 
+## 開発ワークフロー
+
+機能追加・不具合修正は Superpowers の7段階ワークフロー（ブレインストーミング → git worktree →
+計画 → サブエージェント駆動 → TDD → コードレビュー → ブランチ完了）に従う。
+以下は、このリポジトリ固有の制約として上書きする事項。
+
+### 計画を分割するときの制約
+
+- **TypeScript と Python の数値実装は分割しない。** `packages/core` と `packages/core-py` は
+  同じ計算の二重実装で、自動テストが数値一致を固定している。片方だけ変えるとテストが落ちるため、
+  対応する変更・ゴールデン値・ドキュメントは1つのタスク（1コミット）にまとめる。
+- 受入スクリプトの数値ゴールデン（`scripts/acceptance.mjs` の `GOLDEN_NUMERICS`）が動いたときは、
+  値を書き換えるだけで済ませない。**なぜ動いたのかをコメントに残す**（旧値・変化の物理的な理由）。
+  ドキュメントに同じ数字が載っていることが多いので、あわせて追う。
+- 作業ログ・設計メモは `.superpowers/` に置かれるが、ここは gitignore 対象である。
+  **ブランチを終える前に、設計判断は `docs/` 配下の恒久文書へ移すこと。**
+  過去に拡張合意 A1〜A11 が作業ログにしか存在しない状態が生じ、`docs/design-workspace.md` へ
+  統合して解消した経緯がある。
+
+### 完了の判定
+
+「動いた」ではなく、**CIと同じ手順で確認できた**ことをもって完了とする。CIは次の順に実行する。
+
+```bash
+npm run build && npm run test --workspaces --if-present && npm run typecheck && npm run lint
+python -m pytest packages/core-py -q
+npm run acceptance
+npx playwright test --config apps/web-free/playwright.config.ts
+```
+
+落とし穴が3つある。いずれも実際に誤った報告を生んだもの。
+
+- **`npm run build` / `npm run typecheck` は、テストファイルを追加・変更した後にもう一度通す。**
+  ビルドはインクリメンタルなので、追加前のビルド結果が再利用され、型エラーがCIで初めて出ることがある。
+  疑わしいときは `.tsbuildinfo` を消してから走らせる。
+- **web-free のテストはワークスペース単位で起動する**（`npm run test --workspace web-free`）。
+  リポジトリ直下で `vitest` を直接叩くと jsdom 環境設定が効かず、無関係な失敗が大量に出る。
+  ワーカー起動がタイムアウトする場合は `-- --maxWorkers=2` を付ける。
+- **`npm run acceptance` は worktree が汚れていると最後の1項目が必ず落ちる**（意図した挙動）。
+  コミット後に確認する。
+
 ## UI wording
 
 利用者向け画面の新規機能追加・改修・レビューを行う前に、`docs/ui-terminology.md` を読むこと。

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,9 @@
+<!--
+このファイルは AGENTS.md を Claude Code に読ませるためだけに存在する。
+Claude Code は CLAUDE.md しか自動で読み込まず、AGENTS.md（Codex 等が読む）は対象外のため、
+同じ内容を二重管理せずに済むよう import している。
+指示の本体は AGENTS.md 側に書くこと。
+Windows ではシンボリックリンクに管理者権限が要るので、@ import を使っている。
+-->
+
+@AGENTS.md


### PR DESCRIPTION
Superpowers の7段階ワークフロー（ブレインストーミング → git worktree → 計画 → サブエージェント駆動 → TDD → コードレビュー → ブランチ完了）を既定として採用するにあたり、このリポジトリ固有の制約を [AGENTS.md](AGENTS.md) に明文化します。従来は UI 用語の9行だけで、**検証手順がどこにも書かれていませんでした**。

## 計画分割の制約

- **TS と Python の数値実装は分割しない。** `packages/core` と `packages/core-py` は同じ計算の二重実装で、自動テストが数値一致を固定しています。実装・ゴールデン値・ドキュメントを別タスクに割ると、どのタスク単独でもテストが通りません（[PR #53](https://github.com/russENG/open-waterhammer/pull/53) がまさにこの形でした）。
- 受入スクリプトの数値ゴールデンが動いたときは、**なぜ動いたのかをコメントに残す**。同じ数字がドキュメントにも載っていることが多いため。
- 作業ログは `.superpowers/`（gitignore 対象）に残るので、**設計判断はブランチを終える前に `docs/` へ移す**。拡張合意 A1〜A11 が作業ログにしか存在しない状態を [design-workspace.md](docs/design-workspace.md) へ統合して解消した経緯があり、全面適用で再発しやすい箇所です。

## 完了の判定

「動いた」ではなく「CIと同じ手順で確認できた」ことを完了とし、実際に誤った報告を生んだ落とし穴を3つ記録しました。

1. インクリメンタルビルドがテスト追加後の型エラーを拾わない（PR #53 のCI失敗の原因）
2. リポジトリ直下から `vitest` を直接叩くと jsdom 設定が効かず、無関係な失敗が大量に出る
3. `npm run acceptance` は worktree が汚れていると最後の1項目が必ず落ちる（意図した挙動）

記載したコマンドはすべて実行して確認済みです。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
