### PR TITLE
fix(web): サンプルの縦断図を成果品様式に沿った線形にし、既定を主要解析にする

### DIFF
--- a/apps/web-free/src/results/ResultsPanel.tsx
+++ b/apps/web-free/src/results/ResultsPanel.tsx
@@ -46,6 +46,19 @@ function envelopeRows(envelope: PlotLine): CsvRow[] {
   ]
 }
 
+/**
+ * 時系列と圧力包絡を記録するのは特性曲線法（主要解析）だけで、準備計算や簡易確認の
+ * 計算結果には最初から入っていない。以前は方式によらず「この計算結果に時系列は
+ * ありません」とだけ出していたため、既定の波速計算をそのまま実行した利用者には
+ * 計算が失敗したのか記録が壊れたのか区別が付かなかった。方式の違いだと分かるように
+ * 理由と次の操作を書き分ける。
+ */
+function seriesEmptyNote(run: Run, label: string): string {
+  return run.kind.startsWith('transient_')
+    ? `この計算結果に${label}はありません。`
+    : `${runKindLabel(run.kind)}は${label}を出力しない計算方法です。解析タブの主要解析（特性曲線法）で計算すると記録されます。`
+}
+
 function seriesRows(series: Series, valueHeader: string): CsvRow[] {
   return [['t', valueHeader], ...series.seconds.map((t, index): CsvRow => [t, series.values[index] ?? ''])]
 }
@@ -128,7 +141,7 @@ export function ResultsPanel({ caseRecord, runs, selectedRun, focus, onSelectRun
             </svg>
             <ChartLegend items={[{ label: `${timeSeries.id} · H` }]} />
             <ChartActions svgRef={timeSeriesSvgRef} filenameBase={`time-series-${timeSeries.id}`} rows={seriesRows(timeSeries, 'H')} />
-          </> : <div className="empty-ledger"><span>∿</span><p>この計算結果に時系列はありません。</p></div>}
+          </> : <div className="empty-ledger"><span>∿</span><p>{seriesEmptyNote(run, '時系列')}</p></div>}
         </section>
         <section className="notebook-card envelope-card">
           <div className="chart-heading"><div><span className="eyebrow">圧力包絡</span><h2>保存済みの最大・最小水頭</h2></div><span>{envelope?.id ?? '記録なし'}</span></div>
@@ -142,7 +155,7 @@ export function ResultsPanel({ caseRecord, runs, selectedRun, focus, onSelectRun
             </svg>
             <ChartLegend items={[{ label: '定常水頭 H' }, { label: '最大水頭 H', className: 'legend-max' }, { label: '最小水頭 H', className: 'legend-min' }]} />
             <ChartActions svgRef={envelopeSvgRef} filenameBase={`envelope-${envelope.id}`} rows={envelopeRows(envelope)} />
-          </div> : <div className="empty-ledger"><span>—</span><p>包絡線は記録されていません。</p></div>}
+          </div> : <div className="empty-ledger"><span>—</span><p>{seriesEmptyNote(run, '圧力包絡線')}</p></div>}
         </section>
         <section className="notebook-card findings-card"><div className="chart-heading"><div><span className="eyebrow">自動評価</span><h2>関連する指摘事項</h2></div><span>{run.assessment.findings.length}</span></div>{run.assessment.findings.length ? <ol>{run.assessment.findings.map((finding) => <li key={`${finding.ruleId}-${finding.targetRef}`}><button aria-pressed={focus?.targetRef === finding.targetRef} onClick={() => onFocus(createLinkedFocus(finding))}><span className={`ng-marker ng-marker--${run.assessment.status}`}>{assessmentStatusLabel(run.assessment.status)}</span><div><strong>{finding.targetRef} · {finding.location ?? '位置情報なし'}</strong><small>{findingRuleLabel(finding.ruleId)}：{formatFindingValue(finding.observedValue)} / 許容 {formatFindingValue(finding.threshold)} {finding.unit}</small></div><span>連動 ↗</span></button></li>)}</ol> : <div className="empty-ledger"><span>{run.assessment.status === 'needs_review' ? '?' : '✓'}</span><p>{assessmentNote(run)}</p></div>}</section>
         <section className="notebook-card profile-card">

--- a/apps/web-free/src/workspace/__tests__/MethodSelectionGuide.test.tsx
+++ b/apps/web-free/src/workspace/__tests__/MethodSelectionGuide.test.tsx
@@ -68,7 +68,7 @@ describe('MethodSelectionGuide', () => {
     const user = userEvent.setup()
     setupAnalysisPanel()
 
-    expect(screen.getByRole('radio', { name: /波速/ })).toBeChecked()
+    expect(screen.getByRole('radio', { name: /管路網の過渡解析/ })).toBeChecked()
     const groupHeadings = screen.getAllByRole('heading', { level: 2 }).map((heading) => heading.textContent)
     expect(groupHeadings.slice(0, 3)).toEqual(['主要解析', '準備計算', '簡易確認'])
     expect(screen.getAllByRole('radio')).toHaveLength(11)
@@ -88,7 +88,7 @@ describe('MethodSelectionGuide', () => {
     await user.click(screen.getByRole('button', { name: /経験式による水撃圧/ }))
 
     expect(screen.getByRole('radio', { name: /経験式による水撃圧/ })).toBeChecked()
-    expect(screen.getByRole('radio', { name: /波速/ })).not.toBeChecked()
+    expect(screen.getByRole('radio', { name: /管路網の過渡解析/ })).not.toBeChecked()
     expect(screen.getByRole('heading', { level: 2, name: '経験式による水撃圧' })).toBeVisible()
     const advanced = screen.getByText(/詳細な計算条件（3項目）/).closest('details')
     expect(advanced).not.toHaveAttribute('open')

--- a/apps/web-free/src/workspace/__tests__/WorkspaceApp.test.tsx
+++ b/apps/web-free/src/workspace/__tests__/WorkspaceApp.test.tsx
@@ -183,7 +183,8 @@ describe('full workspace application', () => {
     await user.click(within(screen.getByRole('navigation', { name: '作業タブ' })).getByRole('link', { name: '解析' }))
     await waitFor(() => expect(window.location.hash).toContain(`/cases/${createdId}/analysis`))
 
-    // Default kind (wave_speed) is a form-only calculation: no GIS topology needed at all.
+    // Default kind (transient_single_pipe) is a form-only calculation: no GIS topology needed.
+    expect(await screen.findByRole('radio', { name: /単一管路の過渡解析/ })).toBeChecked()
     expect(await screen.findByText('フォーム入力のみ', {}, { timeout: 5_000 })).toBeVisible()
 
     // A network kind on the very same untouched Case is correctly identified as topology-required
@@ -339,7 +340,9 @@ describe('full workspace application', () => {
     const tabs = screen.getByRole('navigation', { name: '作業タブ' })
 
     await user.click(within(tabs).getByRole('link', { name: '解析' }))
-    const diameter = await screen.findByLabelText(/管内径/)
+    // 解析タブの既定はネットワークを持つ比較案では管路網の過渡解析なので、
+    // 編集する数値もその方式の主要フィールドから採る。
+    const diameter = await screen.findByLabelText(/第1管路 内径/)
     await user.clear(diameter)
     await user.type(diameter, '0.31')
     expect(screen.getByRole('button', { name: '計算を実行' })).toBeDisabled()
@@ -388,7 +391,7 @@ describe('full workspace application', () => {
     expect(await screen.findByRole('status')).toHaveTextContent('静水圧は必須です。')
     current = (await repository.snapshot()).cases.find(({ id }) => id === data.cases.at(-1)!.id)!
     empirical = (current.modelSnapshot as { runInputs: Record<string, Record<string, unknown>> }).runInputs.empirical_pressure!
-    expect(empirical.staticPressureMpa).toBe(0.42)
+    expect(empirical.staticPressureMpa).toBe(0.27)
   })
 
   test('persists explicitly mapped GeoJSON drafts into the selected Case', async () => {

--- a/apps/web-free/src/workspace/__tests__/engineering-fields.test.ts
+++ b/apps/web-free/src/workspace/__tests__/engineering-fields.test.ts
@@ -95,7 +95,24 @@ describe('RunKind engineering field catalog', () => {
       const expectedTemplateModel = sample && typeof sample === 'object' && !Array.isArray(sample)
         ? Object.fromEntries(Object.entries(sample).filter(([key]) => key !== 'allowablePressureMpa'))
         : sample
-      expect(ENGINEERING_TEMPLATES[kind].model, kind).toEqual(expectedTemplateModel)
+      // longitudinal_hydraulics is the one kind whose fresh-draft template deliberately
+      // diverges from the sample: the sample carries the demo route's 11 survey stations so
+      // its 縦断図 reads like a real one, while a fresh draft gets a start/end skeleton
+      // instead of ~110 prefilled inputs belonging to another route. Every other key must
+      // still match, and the per-station keys must be the same shape.
+      if (kind === 'longitudinal_hydraulics') {
+        const { points: templatePoints, ...templateRest } = ENGINEERING_TEMPLATES[kind].model as Record<string, unknown>
+        const { points: samplePoints, ...sampleRest } = expectedTemplateModel as Record<string, unknown>
+        expect(Object.keys(templateRest).sort()).toEqual(Object.keys(sampleRest).sort())
+        expect(templatePoints).toHaveLength(2)
+        expect((samplePoints as unknown[]).length).toBeGreaterThan(2)
+        const sampleStationKeys = [...new Set((samplePoints as Array<Record<string, unknown>>).flatMap((station) => Object.keys(station)))]
+        for (const station of templatePoints as Array<Record<string, unknown>>) {
+          expect(sampleStationKeys).toEqual(expect.arrayContaining(Object.keys(station)))
+        }
+      } else {
+        expect(ENGINEERING_TEMPLATES[kind].model, kind).toEqual(expectedTemplateModel)
+      }
       const descriptors = engineeringFieldsFor(kind, ENGINEERING_TEMPLATES[kind])
       const described = new Set(descriptors.map(({ target, path }) => `${target}.${path}`))
       const expected = (['model', 'event', 'boundary', 'protection'] as const).flatMap((target) =>
@@ -132,8 +149,8 @@ describe('RunKind engineering field catalog', () => {
     const darcy = updateEngineeringFieldFromInput(hazen, method, 'darcy-weisbach', 'steady_single_pipe')
 
     expect(darcy.model).toEqual({
-      method: 'darcy-weisbach', innerDiameter: 0.3, length: 500, flowRate: 0.03,
-      upstreamElevation: 100, downstreamElevation: 88, frictionFactor: 0.02,
+      method: 'darcy-weisbach', innerDiameter: 0.3, length: 500, flowRate: 0.07,
+      upstreamElevation: 138.5, downstreamElevation: 114, frictionFactor: 0.02,
     })
     const darcyFields = engineeringFieldsFor('steady_single_pipe', darcy).filter(({ target }) => target === 'model')
     expect(darcyFields.map(({ path }) => path).sort()).toEqual([
@@ -146,8 +163,8 @@ describe('RunKind engineering field catalog', () => {
     const darcyMethod = darcyFields.find(({ path }) => path === 'method')!
     const hazenAgain = updateEngineeringFieldFromInput(darcy, darcyMethod, 'hazen-williams', 'steady_single_pipe')
     expect(hazenAgain.model).toEqual({
-      method: 'hazen-williams', innerDiameter: 0.3, length: 500, flowRate: 0.03,
-      upstreamElevation: 100, downstreamElevation: 88, roughnessC: 130,
+      method: 'hazen-williams', innerDiameter: 0.3, length: 500, flowRate: 0.07,
+      upstreamElevation: 138.5, downstreamElevation: 114, roughnessC: 130,
     })
     expect(engineeringFieldsFor('steady_single_pipe', hazenAgain).some(({ path }) => path === 'frictionFactor')).toBe(false)
   })
@@ -550,8 +567,8 @@ describe('RunKind engineering field catalog', () => {
     const darcy = updateEngineeringFieldFromInput(initial, method, 'darcy-weisbach', 'steady_single_pipe')
     const clearedDarcy = updateEngineeringFieldFromInput(darcy, engineeringFieldsFor('steady_single_pipe', darcy).find(({ path }) => path === 'method')!, '', 'steady_single_pipe')
     expect(clearedDarcy.model).toEqual({
-      innerDiameter: 0.3, length: 500, flowRate: 0.03, upstreamElevation: 100,
-      downstreamElevation: 88, roughnessC: 130,
+      innerDiameter: 0.3, length: 500, flowRate: 0.07, upstreamElevation: 138.5,
+      downstreamElevation: 114, roughnessC: 130,
     })
 
     const trip = structuredClone(ENGINEERING_TEMPLATES.transient_pump)

--- a/apps/web-free/src/workspace/engineering-fields.ts
+++ b/apps/web-free/src/workspace/engineering-fields.ts
@@ -142,14 +142,17 @@ const EVENT_TEMPLATES: Record<RunKind, JsonValue> = {
   transient_protection_device: {},
 }
 
+// sample-workspace.ts の SAMPLE_RUN_INPUTS.steady_single_pipe と同じ諸元（呑口 138.50 m →
+// 分水工 114.00 m、計画最大流量 0.070 m³/s）。方式を切り替えても標高・流量が変わらないよう、
+// 両分岐で揃えておく。
 const STEADY_SINGLE_PIPE_BRANCHES: Record<string, JsonValue> = {
   'hazen-williams': {
-    method: 'hazen-williams', innerDiameter: 0.3, length: 500, flowRate: 0.03,
-    upstreamElevation: 100, downstreamElevation: 88, roughnessC: 130,
+    method: 'hazen-williams', innerDiameter: 0.3, length: 500, flowRate: 0.07,
+    upstreamElevation: 138.5, downstreamElevation: 114, roughnessC: 130,
   },
   'darcy-weisbach': {
-    method: 'darcy-weisbach', innerDiameter: 0.3, length: 500, flowRate: 0.03,
-    upstreamElevation: 100, downstreamElevation: 88, frictionFactor: 0.02,
+    method: 'darcy-weisbach', innerDiameter: 0.3, length: 500, flowRate: 0.07,
+    upstreamElevation: 138.5, downstreamElevation: 114, frictionFactor: 0.02,
   },
 }
 
@@ -169,7 +172,7 @@ const TRANSIENT_PUMP_EVENT_BRANCHES: Record<string, JsonValue> = {
 // closing valve): a device may not replace an event-carrying valve/pump node (Task 4b-2 fix
 // round 1). initialLevel matches J-01's natural steady head in that network.
 const PROTECTION_TEMPLATES: Record<RunKind, JsonValue> = Object.fromEntries(RUN_KINDS.map((kind) => [kind, kind === 'transient_protection_device'
-  ? { devices: [{ id: 'J-01', type: 'surge_tank', enabled: true, tankArea: 4, initialLevel: 78.7 }] }
+  ? { devices: [{ id: 'J-01', type: 'surge_tank', enabled: true, tankArea: 4, initialLevel: 140.7 }] }
   : {}])) as Record<RunKind, JsonValue>
 
 // allowablePressureMpa is demo-only seasoning on SAMPLE_RUN_INPUTS (sample-workspace.ts) so
@@ -185,8 +188,31 @@ function withoutDemoOnlyAllowablePressure(model: JsonValue): JsonValue {
   return allowablePressureMpa === undefined ? model : rest
 }
 
+// The demo route's longitudinal input carries 11 survey stations (sample-workspace.ts) so the
+// sample's profile reads like a real 縦断図. A brand-new draft must not inherit all 11: that is
+// ~110 prefilled elevation and loss inputs belonging to another route, which the engineer would
+// have to overwrite row by row. Fresh drafts get a start/end skeleton instead — the same two-row
+// shape the sample itself had before it gained its intermediate stations — and add their own
+// stations with the 測点 collection control.
+const BLANK_PROFILE_STATION = {
+  pipeId: 'P-01', flowRate: 0.07, diameter: 0.3, roughnessC: 130,
+  bendLossCoeff: 0, valveLossCoeff: 0, branchLossCoeff: 0,
+}
+const LONGITUDINAL_BLANK_MODEL: JsonValue = {
+  caseName: '計画最大流量', staticWaterLevel: 142, waterhammerRatio: 0.2,
+  points: [
+    { id: 'STA-000', ...BLANK_PROFILE_STATION, nodeId: 'R-01', distanceAlongPipe: 0, horizontalDistance: 0, groundLevel: 143, pipeCenterHeight: 138.5, pipeLength: 0 },
+    { id: 'STA-500', ...BLANK_PROFILE_STATION, nodeId: 'J-01', distanceAlongPipe: 500, horizontalDistance: 500, groundLevel: 115.2, pipeCenterHeight: 114, pipeLength: 500 },
+  ],
+}
+
+function blankDraftModel(kind: RunKind): JsonValue {
+  if (kind === 'longitudinal_hydraulics') return LONGITUDINAL_BLANK_MODEL
+  return withoutDemoOnlyAllowablePressure(SAMPLE_RUN_INPUTS[kind])
+}
+
 export const ENGINEERING_TEMPLATES = Object.fromEntries(RUN_KINDS.map((kind) => [kind, {
-  model: structuredClone(withoutDemoOnlyAllowablePressure(SAMPLE_RUN_INPUTS[kind])),
+  model: structuredClone(blankDraftModel(kind)),
   event: structuredClone(EVENT_TEMPLATES[kind]),
   boundary: {},
   protection: structuredClone(PROTECTION_TEMPLATES[kind]),

--- a/apps/web-free/src/workspace/sample-workspace.ts
+++ b/apps/web-free/src/workspace/sample-workspace.ts
@@ -18,6 +18,24 @@ const pipe = {
   length: 500, roughnessCoeff: 130,
 }
 
+// ─── サンプル路線の水理諸元 ─────────────────────────────────────────────────
+//
+// 一つの自然流下パイプラインを、全ての計算方法が同じ標高基準で共有する。
+// 上流端 R-01 は調整池（常時満水位 HWL 142.00 m、呑口の管中心高 138.50 m）、
+// 下流端 V-01/J-01 は分水工の制水弁（管中心高 114.00 m）。計画最大流量
+// 0.070 m³/s（φ300 で流速 0.990 m/s）で摩擦損失は 500 m あたり約 1.66 m
+// なので、定常の動水位は 142.00 → 140.30 m とごく緩く下がる。
+// 以前のサンプルは方式ごとに標高基準がばらばら（定常は 100/88 m、過渡は
+// 水頭 80/30 m）で、結果タブが同じ縦断図に重ねると最小水頭の線が管中心高の
+// はるか下に描かれ、読み取れる図になっていなかった。
+const STATIC_WATER_LEVEL = 142
+/** 定常時に分水工（下流端）へ届く水頭 [m] = HWL − 管路全長の摩擦損失。 */
+const DOWNSTREAM_STEADY_HEAD = 140.3
+const INTAKE_PIPE_CENTER = 138.5
+const OUTLET_PIPE_CENTER = 114
+/** 計画最大流量 [m³/s]。φ300 で流速 0.990 m/s（技術書の推奨流速の範囲内）。 */
+const DESIGN_FLOW = 0.07
+
 const network: JsonValue = {
   caseName: '取水支線 定常解析',
   pipes: [{
@@ -25,25 +43,58 @@ const network: JsonValue = {
     innerDiameter: 0.3, length: 500, roughnessC: 130, minorLossCoeff: 0,
   }],
   nodes: [
-    { id: 'R-01', elevation: 100, type: 'reservoir', head: 142 },
-    { id: 'J-01', elevation: 88, type: 'demand', demand: 0.03 },
+    { id: 'R-01', elevation: INTAKE_PIPE_CENTER, type: 'reservoir', head: STATIC_WATER_LEVEL },
+    { id: 'J-01', elevation: OUTLET_PIPE_CENTER, type: 'demand', demand: DESIGN_FLOW },
   ],
 }
 
 const transientNetwork = {
   pipes: [{
-    id: 'P-01', pipe, nReaches: 10, upstreamNodeId: 'R-01', downstreamNodeId: 'V-01', initialFlow: 0.07,
+    id: 'P-01', pipe, nReaches: 10, upstreamNodeId: 'R-01', downstreamNodeId: 'V-01', initialFlow: DESIGN_FLOW,
   }],
   nodes: {
-    'R-01': { type: 'reservoir', head: 80 },
-    'V-01': { type: 'valve', Q0: 0.07, H0v: 30, closeTime: 2, operation: 'close' },
+    'R-01': { type: 'reservoir', head: STATIC_WATER_LEVEL },
+    'V-01': { type: 'valve', Q0: DESIGN_FLOW, H0v: DOWNSTREAM_STEADY_HEAD, closeTime: 2, operation: 'close' },
   },
 }
 
-const longitudinalPoints: MeasurementPoint[] = [
-  { id: 'STA-000', pipeId: 'P-01', nodeId: 'R-01', distanceAlongPipe: 0, horizontalDistance: 0, groundLevel: 100, pipeCenterHeight: 98, pipeLength: 0, flowRate: 0.03, diameter: 0.3, roughnessC: 130, bendLossCoeff: 0, valveLossCoeff: 0, branchLossCoeff: 0 },
-  { id: 'STA-500', pipeId: 'P-01', nodeId: 'J-01', distanceAlongPipe: 500, horizontalDistance: 500, groundLevel: 90, pipeCenterHeight: 88, pipeLength: 500, flowRate: 0.03, diameter: 0.3, roughnessC: 130, bendLossCoeff: 0.2, valveLossCoeff: 0, branchLossCoeff: 0 },
-]
+// 縦断測点。農水省 成果品様式「計画最大流量時の水理計算書」に倣い、屈曲工・
+// 空気弁工・排泥工といった変化点で区切る（等間隔の測点ではない）。
+// 管長 SL は前測点からの実延長、単距離 Lh は同じ区間の水平距離 √(SL²−Δ管中心高²)、
+// distanceAlongPipe は SL の累計で、末端が管路延長 500 m に一致する。
+// 地盤高は一般部で管中心高 +1.20 m（標準土被り）。起点だけは調整池の堤天高。
+// 195 m と 395 m の凸部が空気弁の設置位置で、過渡解析でも最小水頭が最も
+// 管中心高に近づく（＝負圧の検討箇所）ため、サンプルとして意味のある形にした。
+const longitudinalPoints: MeasurementPoint[] = ([
+  // [測点距離, 管中心高 FH, 地盤高 GL, 単距離 Lh, 曲管損失係数 fb, 弁損失係数 fv, 名称]
+  [0, 138.5, 143, 0, 0, 0, '調整池 呑口'],
+  [45, 136.2, 137.4, 44.94, 0.1, 0, '屈曲工'],
+  [100, 132.4, 133.6, 54.87, 0.05, 0, ''],
+  [150, 130.1, 131.3, 49.95, 0.1, 0, '排泥工'],
+  [195, 131.3, 132.5, 44.98, 0.12, 0, '空気弁工'],
+  [250, 128.6, 129.8, 54.93, 0.05, 0, ''],
+  [300, 124.3, 125.5, 49.81, 0.06, 0, ''],
+  [350, 121.1, 122.3, 49.9, 0.1, 0, '排泥工'],
+  [395, 122.4, 123.6, 44.98, 0.12, 0, '空気弁工'],
+  [440, 119.2, 120.4, 44.89, 0.05, 0, ''],
+  [500, 114, 115.2, 59.77, 0.08, 0.2, '分水工 制水弁'],
+] as const).map(([distance, pipeCenterHeight, groundLevel, horizontalDistance, bendLossCoeff, valveLossCoeff, name], index, rows) => ({
+  id: `STA-${String(distance).padStart(3, '0')}`,
+  ...(name ? { name } : {}),
+  pipeId: 'P-01',
+  ...(index === 0 ? { nodeId: 'R-01' } : index === rows.length - 1 ? { nodeId: 'J-01' } : {}),
+  distanceAlongPipe: distance,
+  horizontalDistance,
+  groundLevel,
+  pipeCenterHeight,
+  pipeLength: distance - (rows[index - 1]?.[0] ?? 0),
+  flowRate: DESIGN_FLOW,
+  diameter: 0.3,
+  roughnessC: 130,
+  bendLossCoeff,
+  valveLossCoeff,
+  branchLossCoeff: 0,
+}))
 
 // Dedicated network for transient_protection_device (does NOT share transientNetwork):
 // R-01 --P-01-- J-01 --P-02-- V-01. V-01 keeps the same closing-valve event as
@@ -61,7 +112,7 @@ const protectionNetwork = {
         pipeType: 'ductile_iron', innerDiameter: 0.3, wallThickness: 0.007,
         length: 400, roughnessCoeff: 130,
       },
-      nReaches: 8, upstreamNodeId: 'R-01', downstreamNodeId: 'J-01', initialFlow: 0.07,
+      nReaches: 8, upstreamNodeId: 'R-01', downstreamNodeId: 'J-01', initialFlow: DESIGN_FLOW,
     },
     {
       id: 'P-02',
@@ -70,13 +121,13 @@ const protectionNetwork = {
         pipeType: 'ductile_iron', innerDiameter: 0.3, wallThickness: 0.007,
         length: 100, roughnessCoeff: 130,
       },
-      nReaches: 2, upstreamNodeId: 'J-01', downstreamNodeId: 'V-01', initialFlow: 0.07,
+      nReaches: 2, upstreamNodeId: 'J-01', downstreamNodeId: 'V-01', initialFlow: DESIGN_FLOW,
     },
   ],
   nodes: {
-    'R-01': { type: 'reservoir', head: 80 },
+    'R-01': { type: 'reservoir', head: STATIC_WATER_LEVEL },
     'J-01': { type: 'junction' },
-    'V-01': { type: 'valve', Q0: 0.07, H0v: 30, closeTime: 2, operation: 'close' },
+    'V-01': { type: 'valve', Q0: DESIGN_FLOW, H0v: DOWNSTREAM_STEADY_HEAD, closeTime: 2, operation: 'close' },
   },
 }
 
@@ -86,24 +137,26 @@ export const SAMPLE_RUN_INPUTS: Record<RunKind, JsonValue> = {
     pipe,
     calculationCase: {
       id: 'CALC-01', name: '末端弁閉鎖', operationType: 'valve_close',
-      targetFacilityId: 'V-01', initialVelocity: 1, initialHead: 30,
+      // initialHead は分水工の静水頭 H₀ = 静水位 − 管中心高 = 142.00 − 114.00。
+      targetFacilityId: 'V-01', initialVelocity: 0.99, initialHead: STATIC_WATER_LEVEL - OUTLET_PIPE_CENTER,
     },
     allowablePressureMpa: 0.75,
   },
-  empirical_pressure: { systemType: 'gravity_open', staticPressureMpa: 0.42, allowablePressureMpa: 0.75 },
+  // 静水圧 = 分水工の静水頭 28.0 m ≒ 0.27 MPa。
+  empirical_pressure: { systemType: 'gravity_open', staticPressureMpa: 0.27, allowablePressureMpa: 0.75 },
   steady_single_pipe: {
-    method: 'hazen-williams', innerDiameter: 0.3, length: 500, flowRate: 0.03,
-    upstreamElevation: 100, downstreamElevation: 88, roughnessC: 130,
+    method: 'hazen-williams', innerDiameter: 0.3, length: 500, flowRate: DESIGN_FLOW,
+    upstreamElevation: INTAKE_PIPE_CENTER, downstreamElevation: OUTLET_PIPE_CENTER, roughnessC: 130,
   },
   steady_network_python: network,
   steady_network_epanet: network,
   longitudinal_hydraulics: {
-    caseName: '取水支線縦断', staticWaterLevel: 142, waterhammerRatio: 0.2,
+    caseName: '取水支線縦断', staticWaterLevel: STATIC_WATER_LEVEL, waterhammerRatio: 0.2,
     points: longitudinalPoints as unknown as JsonValue,
     allowablePressureMpa: 0.75,
   },
   transient_single_pipe: { pipe },
-  transient_network: { network: transientNetwork, options: { tMax: 8, initialFlow: 0.07 } },
+  transient_network: { network: transientNetwork, options: { tMax: 8, initialFlow: DESIGN_FLOW } },
   transient_pump: { pipe },
   // Own network (protectionNetwork, not shared with transient_network): V-01's closing-valve
   // event is unchanged, but a junction node J-01 now sits between it and the reservoir so a
@@ -111,13 +164,19 @@ export const SAMPLE_RUN_INPUTS: Record<RunKind, JsonValue> = {
   // that junction instead of the event-carrying valve — packages/core-py's
   // _transient_protection handler swaps it in at run time and forbids targeting V-01 itself
   // (Task 4b-2, fix round 1).
-  transient_protection_device: { network: protectionNetwork, options: { tMax: 8, initialFlow: 0.07 } },
+  transient_protection_device: { network: protectionNetwork, options: { tMax: 8, initialFlow: DESIGN_FLOW } },
 }
 
+// 平面図の線形。45 m 地点の屈曲工で折れる 2 区間で、実長は約 500 m と
+// 管路延長に一致させてある（以前は約 850 m で縦断の測点距離と合っていなかった）。
+const INTAKE_POINT = [139.7000, 35.6800]
+const BEND_POINT = [139.70270, 35.67880]
+const OUTLET_POINT = [139.70440, 35.67735]
+
 const geoDrafts: JsonValue = [
-  { sourceFeatureId: 'R-01', id: 'R-01', kind: 'node', geometry: { type: 'Point', coordinates: [139.700, 35.680] }, properties: { elevation: 100 }, errors: [] },
-  { sourceFeatureId: 'J-01', id: 'J-01', kind: 'node', geometry: { type: 'Point', coordinates: [139.708, 35.684] }, properties: { elevation: 88 }, errors: [] },
-  { sourceFeatureId: 'P-01', id: 'P-01', kind: 'pipe', geometry: { type: 'LineString', coordinates: [[139.700, 35.680], [139.708, 35.684]] }, properties: { startNodeId: 'R-01', endNodeId: 'J-01', innerDiameter: 0.3 }, errors: [] },
+  { sourceFeatureId: 'R-01', id: 'R-01', kind: 'node', geometry: { type: 'Point', coordinates: INTAKE_POINT }, properties: { elevation: INTAKE_PIPE_CENTER }, errors: [] },
+  { sourceFeatureId: 'J-01', id: 'J-01', kind: 'node', geometry: { type: 'Point', coordinates: OUTLET_POINT }, properties: { elevation: OUTLET_PIPE_CENTER }, errors: [] },
+  { sourceFeatureId: 'P-01', id: 'P-01', kind: 'pipe', geometry: { type: 'LineString', coordinates: [INTAKE_POINT, BEND_POINT, OUTLET_POINT] }, properties: { startNodeId: 'R-01', endNodeId: 'J-01', innerDiameter: 0.3 }, errors: [] },
 ]
 
 const sampleCanonicalModel = mergeDraftGeometryIntoCanonicalModel(
@@ -126,8 +185,8 @@ const sampleCanonicalModel = mergeDraftGeometryIntoCanonicalModel(
     crs: 'EPSG:4326',
     pipes: [pipe],
     nodes: [
-      { id: 'R-01', nodeType: 'reservoir', elevation: 100, hydraulicGrade: 142 },
-      { id: 'J-01', nodeType: 'junction', elevation: 88 },
+      { id: 'R-01', nodeType: 'reservoir', elevation: INTAKE_PIPE_CENTER, hydraulicGrade: STATIC_WATER_LEVEL },
+      { id: 'J-01', nodeType: 'junction', elevation: OUTLET_PIPE_CENTER },
     ],
     measurementPoints: longitudinalPoints,
   }).model,
@@ -167,7 +226,9 @@ export function buildSampleWorkspace(timestamp = new Date().toISOString()): Work
     // Matches PROTECTION_TEMPLATES.transient_protection_device in engineering-fields.ts so a
     // freshly-created Case and this seeded one demonstrate the same device (Task 4b-2 fix round 1).
     const protectionSettings: JsonValue = index === 2
-      ? { devices: [{ id: 'J-01', type: 'surge_tank', enabled: true, tankArea: 4, initialLevel: 78.7 }] }
+      // initialLevel は基準標高 0 からの水位、つまり J-01 の定常水頭そのもの
+      // （静水位 142.00 − R-01〜J-01 400 m の摩擦損失 1.33 m）。
+      ? { devices: [{ id: 'J-01', type: 'surge_tank', enabled: true, tankArea: 4, initialLevel: 140.7 }] }
       : {}
     return {
       ...scenarioFixture,
@@ -176,9 +237,9 @@ export function buildSampleWorkspace(timestamp = new Date().toISOString()): Work
       name: index === 0 ? '末端弁 2秒閉鎖' : `${reasons[index]}シナリオ`,
       boundaryConditions: { upstream: 'reservoir', downstream: 'valve' },
       eventSettings: {
-        closeTime: index === 1 ? 8 : 2, waveSpeed: 1100, initialVelocity: 1,
-        initialDownstreamHead: 30, nReaches: 10, tMax: 8, operation: 'close',
-        mode: 'trip', Q0: 0.07, pumpHead: 50, shutdownTime: 0.5,
+        closeTime: index === 1 ? 8 : 2, waveSpeed: 1100, initialVelocity: 0.99,
+        initialDownstreamHead: DOWNSTREAM_STEADY_HEAD, nReaches: 10, tMax: 8, operation: 'close',
+        mode: 'trip', Q0: DESIGN_FLOW, pumpHead: 50, shutdownTime: 0.5,
       },
       protectionSettings,
       createdAt: timestamp,

--- a/apps/web-free/src/workspace/tabs/AnalysisPanel.tsx
+++ b/apps/web-free/src/workspace/tabs/AnalysisPanel.tsx
@@ -58,7 +58,15 @@ export function AnalysisPanel({
   onFork(): void
 }) {
   const { run, saveModel, busy, lastError } = useWorkspace()
-  const [kind, setKind] = useState<RunKind>('wave_speed')
+  // 既定は主要解析。以前の既定 wave_speed は準備計算で、時系列も圧力包絡も出力しない
+  // ため、「サンプルを開く → 計算を実行 → 結果」をそのまま辿ると結果タブが空欄ばかりに
+  // なり、計算が失敗したのか方式の違いなのか読み取れなかった。
+  // 推奨は管路網の過渡解析だが、これはトポロジ必須なので、まだモデルの無い新規比較案では
+  // 開いた瞬間に実行できない状態から始まってしまう。その場合はフォーム入力だけで完結する
+  // 単一管路の過渡解析（同じ主要解析グループ）に倒す。
+  const [kind, setKind] = useState<RunKind>(() => (
+    evaluateRunGate('transient_network', caseRecord).canRun ? 'transient_network' : 'transient_single_pipe'
+  ))
   const modelRoot = root(caseRecord)
   const inputs = modelRoot.runInputs && typeof modelRoot.runInputs === 'object' && !Array.isArray(modelRoot.runInputs)
     ? modelRoot.runInputs as Record<string, JsonValue> : {}

--- a/apps/web-free/src/workspace/tabs/__tests__/OverviewPanel.test.tsx
+++ b/apps/web-free/src/workspace/tabs/__tests__/OverviewPanel.test.tsx
@@ -50,7 +50,7 @@ describe('OverviewPanel legacy hydraulic model compatibility', () => {
     render(<OverviewPanel project={data.projects[0]!} caseRecord={legacyCase} runs={[]} />)
 
     expect(screen.getByRole('group', { name: /実座標平面図、管路1件、節点2件/ })).toBeVisible()
-    expect(screen.getByRole('group', { name: /入力確認図（計算前）、測点2件/ })).toBeVisible()
+    expect(screen.getByRole('group', { name: /入力確認図（計算前）、測点11件/ })).toBeVisible()
     expect(screen.queryByText('縦断図に必要な測点データがありません。')).not.toBeInTheDocument()
   })
 })


### PR DESCRIPTION
サンプルを開いて計算を実行すると、結果タブが「この計算結果に時系列はありません。」ばかりになり、縦断図も測点2件の直線で読み取れる図になっていなかった。

## 既定の計算方式

解析タブの既定が `A01 波速`（準備計算）だった。時系列・圧力包絡を記録するのは特性曲線法（主要解析）だけなので、既定のまま実行すると結果タブが空欄で埋まり、計算が失敗したのか方式の違いなのか読み取れない。

既定をネットワークの有無で分岐させた。トポロジを持つ比較案では推奨の `transient_network`、モデルがまだ無い新規比較案ではフォーム入力だけで完結する `transient_single_pipe`。どちらも主要解析グループなので、開いた直後に実行でき、かつ時系列・圧力包絡・圧力波アニメーションが揃う。

結果タブの空欄文言も方式別に書き分けた。

> 波速は時系列を出力しない計算方法です。解析タブの主要解析（特性曲線法）で計算すると記録されます。

## サンプルの縦断

農水省 成果品様式「計画最大流量時の水理計算書」に倣い、測点を等間隔ではなく屈曲工・空気弁工・排泥工・分水工の変化点で区切る 11 点に置き換えた。管長 SL は前測点からの実延長、単距離 Lh は同区間の水平距離、`distanceAlongPipe` は SL の累計で末端が管路延長 500 m に一致する。地盤高は一般部で管中心高 +1.20 m（標準土被り）、起点のみ調整池の堤天高。

あわせて標高基準を全方式で統一した。従来は定常が標高 100/88 m、過渡が水頭 80/30 m と基準がばらばらで、結果タブが同じ縦断図に重ねると最小水頭の線が管中心高のはるか下に描かれていた。調整池 HWL 142.00 m・呑口 138.50 m から分水工 114.00 m へ、計画最大流量 0.070 m³/s（φ300 で流速 0.990 m/s）で一本化し、平面図の線形も約 850 m から約 500 m に直して管路延長と一致させた。

195 m と 395 m の凸部を空気弁工の位置に置いてある。過渡解析でも最小水頭が最も管中心高に近づく（余裕 1.06 m）ので、負圧の検討箇所として読める図になる。

新規比較案の縦断水理計算だけは、他路線の 11 測点をそのまま引き継がないよう、起終点2点の骨組みをテンプレートとして別に持たせた。

## 実機で確認した値

| 項目 | 値 |
|---|---|
| 定常動水位 | 141.95 → 140.24 m（動水勾配 3.32‰） |
| 過渡 Hmax / Hmin | 182.2 / 122.1 m、自動評価 適合 |
| 最小水頭の余裕 | 全測点で管中心高より上（最小 1.06 m ＠195 m 凸部） |
| 縦断水理計算 L01 | 最大設計内圧 0.309 MPa < 許容 0.75 MPa、警告なし |
| サージタンク（03 空気室追加） | 最悪 Hmax を 18.9% 低減 |

## CI

`AGENTS.md` の完了判定に従い、次を実行して確認した。

- `npm run build` — 成功
- `npm run test --workspaces --if-present` — web-free 255/255 ほか全パッケージ成功
- `npm run typecheck` / `npm run lint` / `npm run lint:wording` — 成功
- `python -m pytest packages/core-py -q` — 273 passed
- `npm run acceptance` — ACCEPTANCE PASSED (23 checks)

Playwright の E2E のみ未実行。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
