### PR TITLE
feat(web): 圧力波の縦断図に線形を重ね、選択と固定の理由を画面に出す

### DIFF
--- a/apps/web-free/src/results/PressureWaveAnimator.css
+++ b/apps/web-free/src/results/PressureWaveAnimator.css
@@ -18,12 +18,27 @@
 .wave-subheading { margin-bottom: 6px; font-size: .68rem; }
 .wave-subheading span { color: var(--ink-soft); font: .6rem var(--mono); }
 .wave-plan-card svg, .wave-profile-card svg { display: block; width: 100%; height: 270px; overflow: visible; }
+/* クリックで時系列・縦断図・包絡線の選択地点が切り替わる要素。cursor だけでは
+   「押せる」と分からないので、ホバーとキーボードフォーカスで見た目を返す。 */
 .wave-plan-pipe, .wave-plan-node { cursor: pointer; }
+.wave-plan-pipe:hover polyline, .wave-plan-node:hover circle { stroke: var(--orange); stroke-width: 3; }
+.wave-plan-pipe:hover polyline { stroke-width: 12; }
+.wave-plan-pipe:focus-visible, .wave-plan-node:focus-visible { outline: 2px solid var(--orange); outline-offset: 2px; }
 .wave-plan-pipe polyline { fill: none; stroke-width: 9; stroke-linecap: round; stroke-linejoin: round; vector-effect: non-scaling-stroke; }
 .wave-plan-pipe text, .wave-plan-node text { fill: var(--ink); font: 700 10px var(--mono); text-anchor: middle; paint-order: stroke; stroke: #fbfaf4; stroke-width: 3px; }
 .wave-plan-node circle { stroke: #fff; stroke-width: 3; vector-effect: non-scaling-stroke; }
 .wave-selected polyline, .wave-selected circle { filter: drop-shadow(0 0 4px var(--orange)); stroke: var(--orange); }
 .wave-profile-line { fill: none; stroke: var(--orange); stroke-width: 4; stroke-linecap: round; stroke-linejoin: round; vector-effect: non-scaling-stroke; }
+/* 地盤高・管中心高は動く水頭線の背景にあたる静的な参照線。縦断図（LongitudinalProfile.css）
+   と同じ色で、太さを落として時刻ごとに動く線と取り違えないようにする。 */
+.wave-profile-ground { fill: none; stroke: #4d5a48; stroke-width: 2; vector-effect: non-scaling-stroke; }
+.wave-profile-pipe { fill: none; stroke: var(--navy); stroke-width: 2; stroke-dasharray: 7 4; vector-effect: non-scaling-stroke; }
+.wave-profile-legend { display: flex; flex-wrap: wrap; gap: 12px; margin-top: 6px; color: var(--ink-soft); font: .58rem var(--mono); }
+.wave-profile-legend span { display: inline-flex; align-items: center; gap: 5px; }
+.wave-profile-legend i { display: block; width: 18px; height: 0; border-top-width: 3px; border-top-style: solid; }
+.wave-profile-legend .wave-legend-head { border-top-color: var(--orange); }
+.wave-profile-legend .wave-legend-ground { border-top-color: #4d5a48; border-top-width: 2px; }
+.wave-profile-legend .wave-legend-pipe { border-top-color: var(--navy); border-top-width: 2px; border-top-style: dashed; }
 .wave-profile-card circle { fill: #fff; stroke: var(--orange); stroke-width: 2; vector-effect: non-scaling-stroke; }
 .wave-profile-card text { fill: var(--ink-soft); font: 9px var(--mono); text-anchor: middle; }
 .wave-axis { stroke: var(--line); stroke-width: 1; vector-effect: non-scaling-stroke; }

--- a/apps/web-free/src/results/PressureWaveAnimator.tsx
+++ b/apps/web-free/src/results/PressureWaveAnimator.tsx
@@ -161,6 +161,11 @@ export function PressureWaveAnimator({ caseRecord, run, focus, onFocus }: {
   const unitLabel = mode === 'head' ? '水頭 H (m)' : '圧力 P (MPa)'
   const unit = mode === 'head' ? 'm' : 'MPa'
   const profileValues = profile?.points.map((point) => profileValue(point, frame, mode, pipeLengths)) ?? []
+  // 縦断図に重ねる静的な参照線の値。水頭表示では地盤高・管中心高の実標高、圧力表示では
+  // 管中心高が定義上 0 MPa になるので 0 だけを軸に含める。
+  const referenceValues = mode === 'head'
+    ? (profile?.points ?? []).flatMap((point) => [point.groundElevation, point.pipeCenterElevation]).filter((value): value is number => value !== undefined)
+    : [0]
 
   return <section className="pressure-wave" aria-label="圧力波アニメーション">
     <div className="wave-heading">
@@ -179,7 +184,7 @@ export function PressureWaveAnimator({ caseRecord, run, focus, onFocus }: {
     <div className="wave-metrics" aria-label="圧力波の数値">
       <article><span>全時刻の最小</span><strong>{displayMinimum.toFixed(2)} {unit}</strong></article>
       <article><span>全時刻の最大</span><strong>{displayMaximum.toFixed(2)} {unit}</strong></article>
-      <article><span>選択地点</span><strong>{selected.id} · {selectedCurrent?.toFixed(2) ?? '—'} {unit}</strong><small>最小 {selectedValues.length ? Math.min(...selectedValues).toFixed(2) : '—'} / 最大 {selectedValues.length ? Math.max(...selectedValues).toFixed(2) : '—'} {unit}</small></article>
+      <article><span>選択地点</span><strong>{selected.id} · {selectedCurrent?.toFixed(2) ?? '—'} {unit}</strong><small>最小 {selectedValues.length ? Math.min(...selectedValues).toFixed(2) : '—'} / 最大 {selectedValues.length ? Math.max(...selectedValues).toFixed(2) : '—'} {unit}</small><small>{focus ? '平面図・縦断図をクリックすると切り替わります' : '未選択のため既定の地点です。平面図・縦断図をクリックすると切り替わります'}</small></article>
     </div>
     <div className="wave-visual-grid">
       <article className="wave-plan-card">
@@ -216,17 +221,34 @@ export function PressureWaveAnimator({ caseRecord, run, focus, onFocus }: {
           const plotWidth = width - 62
           const plotHeight = height - 62
           const maximumDistance = Math.max(...profile.points.map((point) => point.distance), 1)
-          const range = Math.max(displayMaximum - displayMinimum, 1e-9)
+          // 縦軸は水頭のレンジだけでなく、地盤高・管中心高（水頭表示のとき）と圧力 0
+          // （圧力表示のとき）も含める。参照線がレンジ外に出て切れると、波が管中心高を
+          // 下回っているかどうかという、この図で一番読み取りたいことが分からなくなる。
+          const axisMinimum = Math.min(displayMinimum, ...referenceValues)
+          const axisMaximum = Math.max(displayMaximum, ...referenceValues)
+          const range = Math.max(axisMaximum - axisMinimum, 1e-9)
           const x = (distance: number) => left + distance / maximumDistance * plotWidth
-          const y = (value: number) => top + (displayMaximum - value) / range * plotHeight
+          const y = (value: number) => top + (axisMaximum - value) / range * plotHeight
+          const referencePath = (key: 'groundElevation' | 'pipeCenterElevation') => linePath(profile.points.map((point) => ({
+            x: x(point.distance), ...(point[key] === undefined ? {} : { y: y(point[key]!) }),
+          })))
           const dynamicPoints = profile.points.map((point, index) => ({ x: x(point.distance), ...(profileValues[index] === undefined ? {} : { y: y(profileValues[index]!) }) }))
-          return <svg viewBox={`0 0 ${width} ${height}`} role="img" aria-label={`圧力波の縦断図、時刻${frame.time.toFixed(3)}秒`}>
+          return <svg viewBox={`0 0 ${width} ${height}`} role="img" aria-label={`圧力波の縦断図、時刻${frame.time.toFixed(3)}秒、地盤高と管中心高を重ねて表示`}>
             <line x1={left} x2={left + plotWidth} y1={top + plotHeight} y2={top + plotHeight} className="wave-axis" />
+            {mode === 'head'
+              ? <><path d={referencePath('groundElevation')} className="wave-profile-ground" /><path d={referencePath('pipeCenterElevation')} className="wave-profile-pipe" /></>
+              : <line x1={left} x2={left + plotWidth} y1={y(0)} y2={y(0)} className="wave-profile-pipe" />}
             <path d={linePath(dynamicPoints)} className="wave-profile-line" />
             {dynamicPoints.map((point, index) => point.y === undefined ? null : <g key={profile.points[index]!.id}><circle cx={point.x} cy={point.y} r="4" /><text x={point.x} y={height - 16}>{profile.points[index]!.id}</text></g>)}
-            <text x={left} y={top - 8}>{displayMaximum.toFixed(1)} m</text><text x={left} y={top + plotHeight + 14}>{displayMinimum.toFixed(1)} m</text>
+            <text x={left} y={top - 8}>{axisMaximum.toFixed(1)} {unit}</text><text x={left} y={top + plotHeight + 14}>{axisMinimum.toFixed(1)} {unit}</text>
           </svg>
         })() : <p>縦断図に必要な測点データがありません。</p>}
+        <div className="wave-profile-legend" aria-label="縦断図の凡例">
+          <span><i className="wave-legend-head" />{mode === 'head' ? '水頭' : '圧力'}</span>
+          {mode === 'head'
+            ? <><span><i className="wave-legend-ground" />地盤高</span><span><i className="wave-legend-pipe" />管中心高</span></>
+            : <span><i className="wave-legend-pipe" />管中心高（圧力 0）</span>}
+        </div>
       </article>
     </div>
     <div className="wave-bottom-row">

--- a/apps/web-free/src/workspace/LongitudinalProfile.css
+++ b/apps/web-free/src/workspace/LongitudinalProfile.css
@@ -13,11 +13,17 @@
 .profile-series--maximum { stroke: #c74f2d; }
 .profile-series--minimum { stroke: #765ca7; }
 .profile-series--design { stroke: #b07812; stroke-dasharray: 9 5; }
+/* クリックで平面図・時系列・包絡線の選択地点が切り替わる要素。cursor だけでは
+   「押せる」と分からないので、ホバーとキーボードフォーカスで見た目を返す。 */
 .profile-pipe-span { cursor: pointer; }
+.profile-pipe-span:hover line { stroke: var(--orange); }
+.profile-pipe-span:focus-visible, .profile-point:focus-visible { outline: 2px solid var(--orange); outline-offset: 2px; }
 .profile-pipe-span line { stroke: var(--navy); stroke-width: 5; vector-effect: non-scaling-stroke; }
 .profile-pipe-span text { fill: var(--ink); font: 600 12px var(--mono); text-anchor: middle; }
 .profile-pipe-span--selected line { stroke: var(--orange); stroke-width: 8; }
 .profile-point { cursor: pointer; }
+.profile-point:hover circle { stroke: var(--orange); stroke-width: 4; }
+.profile-point:hover > line { stroke: color-mix(in srgb, var(--orange) 55%, transparent); }
 .profile-point > line { stroke: color-mix(in srgb, var(--navy) 20%, transparent); stroke-width: 1; stroke-dasharray: 3 6; vector-effect: non-scaling-stroke; }
 .profile-point circle { fill: #fffaf0; stroke: var(--navy); stroke-width: 2; vector-effect: non-scaling-stroke; }
 .profile-point > path { fill: #b52828; stroke: #fffaf0; stroke-width: 1; }
@@ -26,6 +32,7 @@
 .profile-point--selected circle, .profile-point--selected > path { stroke: var(--orange); stroke-width: 5; }
 .profile-selected-cursor { stroke: var(--orange); stroke-width: 2; stroke-dasharray: 5 4; vector-effect: non-scaling-stroke; pointer-events: none; }
 .profile-axis-labels text { fill: var(--ink-soft); font: 9px var(--mono); }
+.profile-hint { margin: 0; color: var(--ink-soft); font-size: .6rem; }
 .profile-series-legend { display: flex; flex-wrap: wrap; gap: 14px; color: var(--ink-soft); font-size: .62rem; }
 .profile-series-legend span { display: inline-flex; align-items: center; gap: 5px; }
 .profile-series-legend i { display: inline-block; width: 22px; height: 0; border-top: 3px solid; }

--- a/apps/web-free/src/workspace/LongitudinalProfile.tsx
+++ b/apps/web-free/src/workspace/LongitudinalProfile.tsx
@@ -141,6 +141,7 @@ export function LongitudinalProfile({ diagram, mode, focus, onFocus }: {
         </g>
       </svg>
     </div>
+    {onFocus && <p className="profile-hint">測点や管路をクリックすると、その地点の時系列・平面図・圧力包絡が連動して切り替わります。</p>}
     <div className="profile-series-legend" aria-label="縦断図の凡例">
       {visibleSeries.map(({ key, label, className }) => <span key={key}><i className={className} />{label}</span>)}
       <span><i className="profile-legend-invalid" />欠損・不整合</span>

--- a/apps/web-free/src/workspace/tabs/AnalysisMethodSelector.tsx
+++ b/apps/web-free/src/workspace/tabs/AnalysisMethodSelector.tsx
@@ -14,6 +14,10 @@ export function AnalysisMethodSelector({ selectedKind, locked, copy, onSelect }:
   onSelect(kind: RunKind): void
 }) {
   return <div className="run-kind-list analysis-method-groups" role="radiogroup" aria-label="計算の種類">
+    {/* 固定された比較案では11種すべてが無効になる。理由は入力欄の側にも出しているが、
+        利用者がまず見るのはこの一覧なので、無効化された選択肢のところにも短く添える
+        （「主要解析しか選べない」と読まれていた）。 */}
+    {locked && <p className="analysis-method-locked-note">この比較案は計算済み・固定のため、計算方法は変更できません。入力欄の「複製して編集」から、編集できる複製を作れます。</p>}
     {ANALYSIS_METHOD_GROUPS.map((group) => <section key={group.id} className={`analysis-method-group analysis-method-group--${group.id}`} aria-labelledby={`analysis-method-${group.id}`}>
       <div className="analysis-method-group-heading"><h2 id={`analysis-method-${group.id}`}>{group.title}</h2>{group.id === 'primary' && <span>推奨</span>}</div>
       <p>{group.description}</p>

--- a/apps/web-free/src/workspace/tabs/AnalysisPanel.css
+++ b/apps/web-free/src/workspace/tabs/AnalysisPanel.css
@@ -9,6 +9,7 @@
 .analysis-sequence .analysis-sequence--primary b { color: white; background: var(--navy); }
 .analysis-layout { grid-template-columns: 310px minmax(0, 1fr); }
 .run-kind-list.analysis-method-groups { display: block; border: 0; background: transparent; }
+.analysis-method-locked-note { margin: 0 0 10px; padding: 8px 10px; border-left: 3px solid var(--orange); background: color-mix(in srgb, #fff 90%, var(--orange)); color: var(--ink); font-size: .58rem; line-height: 1.6; }
 .analysis-method-group { margin-bottom: 10px; border: 1px solid var(--line-dark); background: var(--white); }
 .analysis-method-group--primary { border: 2px solid var(--navy); box-shadow: 0 5px 14px rgba(20, 47, 73, .1); }
 .analysis-method-group-heading { display: flex; align-items: center; justify-content: space-between; padding: 9px 10px 0; }
@@ -31,7 +32,7 @@
 @media (max-width: 860px) {
   .analysis-layout { grid-template-columns: 1fr; }
   .run-kind-list.analysis-method-groups { display: grid; grid-template-columns: 1fr 1fr; max-height: none; overflow: visible; }
-  .analysis-method-group--primary { grid-column: 1 / -1; }
+  .analysis-method-locked-note, .analysis-method-group--primary { grid-column: 1 / -1; }
 }
 @media (max-width: 560px) {
   .analysis-sequence, .run-kind-list.analysis-method-groups { grid-template-columns: 1fr; }


### PR DESCRIPTION
サンプルを見ながら受けた指摘3点への対応。

## 1. 圧力波アニメーションの縦断図に地盤高・管中心高を重ねる

結果タブには縦断図が2つあり、下部の「縦断」カード（`LongitudinalProfile`）は地盤高・管中心高・動水位・最大水頭・最小水頭を重ねているのに対し、「圧力波の伝播」内の縦断図（[PressureWaveAnimator.tsx:209](apps/web-free/src/results/PressureWaveAnimator.tsx:209)）は**その時刻の水頭線を1本描くだけ**だった。再生中に波が管中心高を下回っているかどうかが読めず、負圧の検討箇所という一番見たいことが図から分からない。サンプルの 195 m の凸部は余裕 1.06 m まで詰まる地点なので、まさにそこが見えなかった。

縦軸は水頭のレンジだけでスケールしていたため、参照線を足すだけでは管中心高がレンジ外で切れる。地盤高・管中心高（水頭表示）と 0（圧力表示）を含むように軸を広げた。圧力表示では管中心高が定義上 0 MPa なので、地盤高は描かず 0 の基準線だけを引く。

あわせて、軸ラベルの単位が圧力表示でも `m` 固定だったのを直した（`unit` を使う）。

| 表示量 | 参照線 | 軸レンジ |
|---|---|---|
| 水頭 | 地盤高・管中心高 | 182.7 〜 114.0 m（従来は 182.7 〜 122.1 m で管中心高が切れていた） |
| 圧力 | 管中心高（圧力 0）のみ | 0.7 〜 −0.1 MPa（従来は単位が `m` 表記） |

## 2. クリックできることを画面に出す

縦断図の測点・管路帯と平面図の管路・節点は `role="button"` でクリックでき、押すと時系列・平面図・圧力包絡の選択地点が連動する（`LinkedFocus`）。ただし `cursor: pointer` 以外に手掛かりが無く、操作できること自体が伝わっていなかった。

- ホバーとキーボードフォーカス（`:focus-visible`）で見た目を返す
- 縦断図に一文の案内を添える（`onFocus` がある結果タブのときだけ。入力確認図には出ない）
- 「選択地点」カードに、未選択のときは既定の地点である旨を明記する

選択の解決順は [PressureWaveAnimator.tsx:68](apps/web-free/src/results/PressureWaveAnimator.tsx:68) のとおりで、今回は挙動を変えていない（`focus.timeSeriesId` → 節点なら節点の H 時系列、そうでなければ管路の `location ÷ 管路延長` 位置、未選択なら最初の管路の中央）。

## 3. 固定された比較案で計算方法が選べない理由を、選択肢のところに出す

比較案が「計算済み・固定」だと11種すべてのラジオが無効になる（[AnalysisMethodSelector.tsx:25](apps/web-free/src/workspace/tabs/AnalysisMethodSelector.tsx:25) の `disabled={locked}`）。理由は入力欄側の注意書きにあるが、利用者がまず見るのは計算方法の一覧のほうで、主要解析グループだけが紺枠＋「推奨」バッジ＋全幅で目立つため「主要解析しか選べない、あえてか？」と読まれた。一覧の先頭にも理由と復帰導線を短く添える。編集中の比較案では出ない。

## CI

- `npm run build` — 成功
- `npm run test --workspaces --if-present` — web-free 255/255、他も全通過
- `npm run typecheck` / `npm run lint` / `npm run lint:wording` — 成功
- `python -m pytest packages/core-py -q` — 273 passed
- `npm run acceptance` — ACCEPTANCE PASSED (23 checks)
- `npx playwright test --config apps/web-free/playwright.config.ts` — 6 passed / 1 skipped（アクセシビリティ検査を含む）

🤖 Generated with [Claude Code](https://claude.com/claude-code)