### PR TITLE
feat(web): 既定の表示地点を設計支配地点にし、圧力レンジを実在値から作る

### DIFF
--- a/apps/web-free/src/results/PressureWaveAnimator.tsx
+++ b/apps/web-free/src/results/PressureWaveAnimator.tsx
@@ -7,9 +7,11 @@ import type { LinkedFocus } from '../workspace/focus'
 import { deriveLongitudinalProfile, type ProfilePoint } from '../workspace/longitudinal-profile'
 import { derivePlanDiagram } from '../workspace/plan-view'
 import {
+  deriveGoverningLocation,
   derivePressureWaveAnimation,
   pressureWaveColor,
   valueAtRatio,
+  type GoverningLocation,
   type PressureWaveAnimationData,
   type PressureWaveFrame,
 } from './pressure-wave'
@@ -65,15 +67,74 @@ function locationDistance(location: string | undefined): number | undefined {
   return Number.isFinite(value) ? value : undefined
 }
 
-function selectedSeries(animation: PressureWaveAnimationData, focus: LinkedFocus | undefined, pipeLengths: Map<string, number>): { id: string; kind: 'pipe' | 'node'; values: Array<number | undefined> } {
+/**
+ * 時系列に出す地点を決める。
+ *
+ * 節点が選ばれていればその節点の水頭時系列。そうでなければ管路上の1点を取る。
+ * 管路上の位置は、測点を選んでいればその距離、選んでいなければ設計を支配する地点
+ * （`deriveGoverningLocation`: 定常水頭からの振れ幅が最大の位置）。以前の既定は
+ * 「最初の管路の中央」で、工学的な意味がなく、開いた直後に見る図としては
+ * 検討すべき地点を指していなかった。
+ */
+function selectedSeries(
+  animation: PressureWaveAnimationData,
+  focus: LinkedFocus | undefined,
+  pipeLengths: Map<string, number>,
+  governing: GoverningLocation | undefined,
+): { id: string; kind: 'pipe' | 'node'; values: Array<number | undefined>; fromGoverning: boolean } {
   const requested = focus?.timeSeriesId || focus?.mapFeatureId
   const nodeId = requested && animation.nodeIds.includes(requested) ? requested : undefined
-  if (nodeId) return { id: nodeId, kind: 'node', values: animation.frames.map((frame) => frame.nodes[nodeId]) }
-  const pipeId = requested && animation.pipeIds.includes(requested) ? requested : animation.pipeIds[0]!
+  if (nodeId) return { id: nodeId, kind: 'node', values: animation.frames.map((frame) => frame.nodes[nodeId]), fromGoverning: false }
+  const requestedPipeId = requested && animation.pipeIds.includes(requested) ? requested : undefined
+  const governingPipeId = governing && animation.pipeIds.includes(governing.pipeId) ? governing.pipeId : undefined
+  const pipeId = requestedPipeId ?? governingPipeId ?? animation.pipeIds[0]!
   const location = locationDistance(focus?.location)
   const length = pipeLengths.get(pipeId) ?? 1
-  const ratio = location !== undefined ? Math.max(0, Math.min(1, location / length)) : 0.5
-  return { id: pipeId, kind: 'pipe', values: animation.frames.map((frame) => valueAtRatio(frame.pipes[pipeId]?.heads ?? [], ratio)) }
+  // 管路は特定できても地点が分からない場合も、その管路の支配地点に寄せる。
+  const governingRatio = pipeId === governingPipeId ? governing!.ratio : undefined
+  const ratio = location !== undefined ? Math.max(0, Math.min(1, location / length)) : governingRatio ?? 0.5
+  return {
+    id: pipeId,
+    kind: 'pipe',
+    values: animation.frames.map((frame) => valueAtRatio(frame.pipes[pipeId]?.heads ?? [], ratio)),
+    fromGoverning: location === undefined && governingRatio !== undefined,
+  }
+}
+
+/**
+ * 軸と色スケールのレンジを、画面に出している値そのものから作る。
+ *
+ * 圧力表示の以前の下限は `最小水頭 − 管中心高の最大値` で、管路全体の最小水頭と、
+ * 別の地点の管中心高を組み合わせた保守的な包絡値だった。どの地点にも存在しない
+ * 負圧が軸に出るため、全測点で正圧でも「負圧が発生している」と読めてしまう。
+ * 平面図の管路平均・節点、縦断図の測点という、実際に描いている値だけを見る。
+ */
+function displayRange(
+  animation: PressureWaveAnimationData,
+  mode: DisplayMode,
+  points: ProfilePoint[],
+  pipeElevations: Map<string, number>,
+  pipeLengths: Map<string, number>,
+  nodeElevations: Map<string, number>,
+): { minimum: number; maximum: number } {
+  if (mode === 'head') return { minimum: animation.minimumHead, maximum: animation.maximumHead }
+  let minimum = Infinity
+  let maximum = -Infinity
+  const observe = (value: number | undefined) => {
+    if (value === undefined || !Number.isFinite(value)) return
+    if (value < minimum) minimum = value
+    if (value > maximum) maximum = value
+  }
+  for (const frame of animation.frames) {
+    for (const pipeId of animation.pipeIds) observe(displayedPipeValue(frame, pipeId, mode, pipeElevations))
+    for (const nodeId of animation.nodeIds) {
+      const head = frame.nodes[nodeId]
+      const elevation = nodeElevations.get(nodeId)
+      if (head !== undefined && elevation !== undefined) observe(headToMpa(head - elevation))
+    }
+    for (const point of points) observe(profileValue(point, frame, mode, pipeLengths))
+  }
+  return minimum <= maximum ? { minimum, maximum } : { minimum: 0, maximum: 0 }
 }
 
 function profileValue(point: ProfilePoint, frame: PressureWaveFrame, mode: DisplayMode, pipeLengths: Map<string, number>): number | undefined {
@@ -126,10 +187,17 @@ export function PressureWaveAnimator({ caseRecord, run, focus, onFocus }: {
   const model = useMemo(() => resolveCanonicalHydraulicModel(caseRecord), [caseRecord])
   const pipeElevations = useMemo(() => elevationByPipe(model), [model])
   const pipeLengths = useMemo(() => new Map((model?.pipes ?? []).map((pipe) => [pipe.id, pipe.length])), [model])
+  const nodeElevations = useMemo(() => new Map((model?.nodes ?? []).flatMap((node) => node.elevation === undefined ? [] : [[node.id, node.elevation] as const])), [model])
+  const governing = useMemo(() => deriveGoverningLocation(run), [run])
   const [frameIndex, setFrameIndex] = useState(0)
   const [playing, setPlaying] = useState(false)
   const [speed, setSpeed] = useState(1)
   const [mode, setMode] = useState<DisplayMode>('head')
+  // 全フレーム × 表示要素を走査するので、フレーム送りのたびに測り直さないよう memo 化する。
+  const range = useMemo(
+    () => animation ? displayRange(animation, mode, profile?.points ?? [], pipeElevations, pipeLengths, nodeElevations) : undefined,
+    [animation, mode, profile, pipeElevations, pipeLengths, nodeElevations],
+  )
 
   useEffect(() => {
     if (!playing || !animation || animation.frames.length < 2) return
@@ -143,21 +211,20 @@ export function PressureWaveAnimator({ caseRecord, run, focus, onFocus }: {
 
   if (!animation) return <div className="wave-empty"><span>∿</span><p>この保存済み計算結果には、再生できる管路内の時刻別水頭分布がありません。</p></div>
   const frame = animation.frames[Math.min(frameIndex, animation.frames.length - 1)]!
-  const selectedRaw = selectedSeries(animation, focus, pipeLengths)
+  const selectedRaw = selectedSeries(animation, focus, pipeLengths, governing)
   const nodeElevation = model?.nodes.find(({ id }) => id === selectedRaw.id)?.elevation
   const selectedDatum = selectedRaw.kind === 'pipe' ? pipeElevations.get(selectedRaw.id) : nodeElevation
   const selected = {
     ...selectedRaw,
+    direction: governing?.direction,
+    excursion: governing?.excursion ?? 0,
     values: selectedRaw.values.map((value) => value === undefined || mode === 'head' ? value : selectedDatum === undefined ? undefined : headToMpa(value - selectedDatum)),
   }
   const selectedValues = selected.values.filter((value): value is number => value !== undefined)
   const selectedCurrent = selected.values[frameIndex]
   const trace = sparkline(selected.values, frameIndex)
-  const profileElevations = profile?.points.map((point) => point.pipeCenterElevation).filter((value): value is number => value !== undefined) ?? []
-  const elevationMinimum = profileElevations.length ? Math.min(...profileElevations) : 0
-  const elevationMaximum = profileElevations.length ? Math.max(...profileElevations) : 0
-  const displayMinimum = mode === 'head' ? animation.minimumHead : headToMpa(animation.minimumHead - elevationMaximum)
-  const displayMaximum = mode === 'head' ? animation.maximumHead : headToMpa(animation.maximumHead - elevationMinimum)
+  // range が undefined になるのは animation が無いときだけで、そこは上で早期に返している。
+  const { minimum: displayMinimum, maximum: displayMaximum } = range ?? { minimum: 0, maximum: 0 }
   const unitLabel = mode === 'head' ? '水頭 H (m)' : '圧力 P (MPa)'
   const unit = mode === 'head' ? 'm' : 'MPa'
   const profileValues = profile?.points.map((point) => profileValue(point, frame, mode, pipeLengths)) ?? []
@@ -184,7 +251,9 @@ export function PressureWaveAnimator({ caseRecord, run, focus, onFocus }: {
     <div className="wave-metrics" aria-label="圧力波の数値">
       <article><span>全時刻の最小</span><strong>{displayMinimum.toFixed(2)} {unit}</strong></article>
       <article><span>全時刻の最大</span><strong>{displayMaximum.toFixed(2)} {unit}</strong></article>
-      <article><span>選択地点</span><strong>{selected.id} · {selectedCurrent?.toFixed(2) ?? '—'} {unit}</strong><small>最小 {selectedValues.length ? Math.min(...selectedValues).toFixed(2) : '—'} / 最大 {selectedValues.length ? Math.max(...selectedValues).toFixed(2) : '—'} {unit}</small><small>{focus ? '平面図・縦断図をクリックすると切り替わります' : '未選択のため既定の地点です。平面図・縦断図をクリックすると切り替わります'}</small></article>
+      <article><span>選択地点</span><strong>{selected.id} · {selectedCurrent?.toFixed(2) ?? '—'} {unit}</strong><small>最小 {selectedValues.length ? Math.min(...selectedValues).toFixed(2) : '—'} / 最大 {selectedValues.length ? Math.max(...selectedValues).toFixed(2) : '—'} {unit}</small><small>{selected.fromGoverning
+        ? `未選択のため、定常からの振れ幅が最大の地点（${selected.direction === 'up' ? '上昇側' : '下降側'} ${selected.excursion.toFixed(1)} m）を表示しています。平面図・縦断図をクリックすると切り替わります`
+        : '平面図・縦断図をクリックすると切り替わります'}</small></article>
     </div>
     <div className="wave-visual-grid">
       <article className="wave-plan-card">

--- a/apps/web-free/src/results/__tests__/pressure-wave.test.tsx
+++ b/apps/web-free/src/results/__tests__/pressure-wave.test.tsx
@@ -4,7 +4,7 @@ import userEvent from '@testing-library/user-event'
 import { describe, expect, test, vi } from 'vitest'
 
 import { PressureWaveAnimator } from '../PressureWaveAnimator'
-import { derivePressureWaveAnimation, PRESSURE_WAVE_MAX_FRAMES, PRESSURE_WAVE_MAX_SPATIAL_SAMPLES, pressureWaveColor, valueAtRatio } from '../pressure-wave'
+import { deriveGoverningLocation, derivePressureWaveAnimation, PRESSURE_WAVE_MAX_FRAMES, PRESSURE_WAVE_MAX_SPATIAL_SAMPLES, pressureWaveColor, valueAtRatio } from '../pressure-wave'
 
 const transientRun: Run = {
   ...runFixture,
@@ -41,6 +41,39 @@ const caseRecord: Case = {
     },
   },
 }
+
+describe('設計を支配する地点', () => {
+  test('上昇側の振れ幅が最大の位置と向きを返す', () => {
+    // transientRun の P1: 上昇側 Hmax−H_steady = [1, 4, 7, 10]、下降側 H_steady−Hmin = [2, 2, 2, 2]。
+    // 最大は末端 (index 3) の上昇側 10 m。
+    expect(deriveGoverningLocation(transientRun)).toEqual({ pipeId: 'P1', ratio: 1, excursion: 10, direction: 'up' })
+  })
+
+  test('下降側のほうが大きければそちらを採る', () => {
+    const downSurge: Run = {
+      ...transientRun,
+      summary: { pipes: { P1: { H_steady: [30, 30, 30], Hmax: [31, 32, 33], Hmin: [30, 20, 29] } } },
+    }
+    // 上昇側は末端の 3 m、下降側は中央の 10 m。大きいほうの中央 (ratio 0.5) を採る。
+    expect(deriveGoverningLocation(downSurge)).toEqual({ pipeId: 'P1', ratio: 0.5, excursion: 10, direction: 'down' })
+  })
+
+  test('複数管路をまたいで最大の1点を選ぶ', () => {
+    const twoPipes: Run = {
+      ...transientRun,
+      summary: { pipes: {
+        P1: { H_steady: [30, 30], Hmax: [33, 34], Hmin: [30, 30] },
+        P2: { H_steady: [30, 30], Hmax: [31, 50], Hmin: [30, 30] },
+      } },
+    }
+    expect(deriveGoverningLocation(twoPipes)).toMatchObject({ pipeId: 'P2', ratio: 1, excursion: 20 })
+  })
+
+  test('包絡線が無い計算結果では地点を決めない', () => {
+    expect(deriveGoverningLocation({ ...transientRun, summary: {} })).toBeUndefined()
+    expect(deriveGoverningLocation({ ...transientRun, summary: { pipes: { P1: {} } } })).toBeUndefined()
+  })
+})
 
 describe('saved pressure-wave animation model', () => {
   test('limits frames and spatial samples while preserving saved first and last values and raw extrema', () => {

--- a/apps/web-free/src/results/pressure-wave.ts
+++ b/apps/web-free/src/results/pressure-wave.ts
@@ -173,6 +173,53 @@ export function derivePressureWaveAnimation(
   }
 }
 
+/** 設計を支配する地点。管路IDと、その管路の起点からの位置比 (0〜1)。 */
+export interface GoverningLocation {
+  pipeId: string
+  ratio: number
+  /** 定常水頭からの最大振れ幅 [m]。上昇側・下降側の大きいほう。 */
+  excursion: number
+  /** 振れの向き。上昇側なら 'up'（設計内圧側）、下降側なら 'down'（負圧側）。 */
+  direction: 'up' | 'down'
+}
+
+/**
+ * 保存済み計算結果の包絡線から、設計を支配する地点を1つ選ぶ。
+ *
+ * 判定は「定常水頭からの振れ幅が最大の位置」。上昇側 (Hmax − H_steady) と
+ * 下降側 (H_steady − Hmin) を同じ水頭 [m] の物差しで比べ、大きいほうを採る。
+ * 上昇側が勝てば設計内圧を、下降側が勝てば負圧・水柱分離を検討すべき地点になる。
+ *
+ * 何も選択していないときに時系列へ出す既定地点として使う。以前の既定は
+ * 「最初の管路の中央」で、工学的な意味がないうえに、なぜそこなのかも画面から
+ * 分からなかった。
+ *
+ * 包絡線 (`summary.pipes[*].Hmax / Hmin / H_steady`) は計算エンジンが全区間で
+ * 求めた値で、アニメーション用に間引く前の解像度を持つ。位置は配列の添字から
+ * 比に直すので、間引かれたフレーム側とも `valueAtRatio` で突き合わせられる。
+ */
+export function deriveGoverningLocation(run: Run): GoverningLocation | undefined {
+  const pipes = record(record(run.summary)?.pipes)
+  if (!pipes) return undefined
+  let best: GoverningLocation | undefined
+  for (const pipeId of Object.keys(pipes).sort()) {
+    const pipe = record(pipes[pipeId])
+    if (!pipe) continue
+    const steady = finiteNumbers(pipe.H_steady)
+    const maximum = finiteNumbers(pipe.Hmax)
+    const minimum = finiteNumbers(pipe.Hmin)
+    const length = Math.min(steady.length, maximum.length, minimum.length)
+    for (let index = 0; index < length; index += 1) {
+      const up = maximum[index]! - steady[index]!
+      const down = steady[index]! - minimum[index]!
+      const excursion = Math.max(up, down)
+      if (!Number.isFinite(excursion) || (best && excursion <= best.excursion)) continue
+      best = { pipeId, ratio: length === 1 ? 0 : index / (length - 1), excursion, direction: up >= down ? 'up' : 'down' }
+    }
+  }
+  return best
+}
+
 export function valueAtRatio(values: number[], ratio: number): number | undefined {
   if (!values.length) return undefined
   if (values.length === 1) return values[0]


### PR DESCRIPTION
[PR #57](https://github.com/russENG/open-waterhammer/pull/57) で範囲外にしていた2件。

## 1. 未選択時の既定を設計支配地点にする

時系列に出す地点は、何も選択していないと「最初の管路の中央」だった。工学的な意味がなく、開いた直後に見る図が検討すべき地点を指していない。サンプルでは P-01 の 250 m が黙って選ばれていた。

包絡線から、**定常水頭からの振れ幅が最大の位置**を選ぶ（`deriveGoverningLocation`）。上昇側 `Hmax − H_steady` と下降側 `H_steady − Hmin` を同じ水頭 [m] の物差しで比べ、大きいほうを採る。上昇側が勝てば設計内圧を、下降側が勝てば負圧・水柱分離を検討すべき地点になる。判定に使う包絡線は計算エンジンが全区間で求めた値なので、アニメーション用に間引く前の解像度で決まる。

管路は特定できても地点が分からない場合（管路帯をクリックしたとき）も、その管路の支配地点に寄せる。測点を選んだときの挙動は変えていない。

なぜその地点なのかが分からないと既定の意味がないので、「選択地点」カードに向きと振れ幅を明記する。

| | 修正前 | 修正後 |
|---|---|---|
| 既定の地点 | P-01 の中央（250 m） | P-01 の分水工端 |
| t=0 の水頭 | 141.13 m | 140.30 m |
| 全時刻の振れ | 132.58 〜 164.07 m | 123.32 〜 182.70 m |
| 説明 | （なし） | 「未選択のため、定常からの振れ幅が最大の地点（上昇側 42.4 m）を表示しています」 |

## 2. 圧力表示のレンジを実在する点の値から作る

圧力表示の下限は `最小水頭 − 管中心高の最大値` で、**管路全体の最小水頭と、別の地点の管中心高**を組み合わせた保守的な包絡値だった。どの地点にも存在しない負圧が軸に出るため、全測点で正圧でも「負圧が発生している」と読めてしまう。サンプルでは実際の最小余裕が 1.06 m あるのに −0.1 MPa と表示されていた。

平面図の管路平均・節点、縦断図の測点という、**実際に描いている値**だけからレンジを作る。

| | 修正前 | 修正後 |
|---|---|---|
| 圧力レンジ | −0.1 〜 0.7 MPa | 0.03 〜 0.67 MPa（いずれも実在する地点の値） |

全フレーム × 表示要素を走査するので、フレーム送りのたびに測り直さないよう memo 化している。

## CI

- `npm run build` — 成功
- `npm run test --workspaces --if-present` — web-free 259/259（支配地点の判定に4件追加）、他も全通過
- `npm run typecheck` / `npm run lint` / `npm run lint:wording` — 成功
- `python -m pytest packages/core-py -q` — 273 passed
- `npm run acceptance` — ACCEPTANCE PASSED (23 checks)
- `npx playwright test --config apps/web-free/playwright.config.ts` — 6 passed / 1 skipped

🤖 Generated with [Claude Code](https://claude.com/claude-code)